### PR TITLE
Please use LocalPath to convert CodeBase instead of AbsolutePath.

### DIFF
--- a/Test/Mono.Cecil.Tests/BaseTestFixture.cs
+++ b/Test/Mono.Cecil.Tests/BaseTestFixture.cs
@@ -53,7 +53,7 @@ namespace Mono.Cecil.Tests {
 
 		public static string FindResourcesDirectory (Assembly assembly)
 		{
-			var path = Path.GetDirectoryName (new Uri (assembly.CodeBase).AbsolutePath);
+			var path = Path.GetDirectoryName (new Uri (assembly.CodeBase).LocalPath);
 			while (!Directory.Exists (Path.Combine (path, "Resources"))) {
 				var old = path;
 				path = Path.GetDirectoryName (path);


### PR DESCRIPTION
System.Uri.AbsolutePath encodes space to %20, so test case is failure when assembly.CodeBase has path that contains space.
Please use System.Uri.LocalPath to convert assembly.CodeBase.
