### PR TITLE
Implemented PdbReaderProvider.GetSymbolReader(Stream)

### DIFF
--- a/symbols/pdb/Mono.Cecil.Pdb/PdbHelper.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/PdbHelper.cs
@@ -65,7 +65,7 @@ namespace Mono.Cecil.Pdb {
 
 		public ISymbolReader GetSymbolReader (ModuleDefinition module, Stream symbolStream)
 		{
-			throw new NotImplementedException ();
+			return new PdbReader (symbolStream);
 		}
 	}
 


### PR DESCRIPTION
I was getting this NotImplementedException when setting SymbolStream on the ReaderParameters. Seems simple enough to implement :)
