### PR TITLE
Small fix for custom attribute signatures

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -2370,8 +2370,12 @@ namespace Mono.Cecil {
 		public void ReadCustomAttributeSignature (CustomAttribute attribute)
 		{
 			var reader = ReadSignature (attribute.signature);
+
+			if (!reader.CanReadMore ())
+				return;
+
 			if (reader.ReadUInt16 () != 0x0001)
-			    throw new InvalidOperationException ();
+				throw new InvalidOperationException ();
 
 			var constructor = attribute.Constructor;
 			if (constructor.HasParameters)


### PR DESCRIPTION
Hi

reader._siglength = 0, so when reader tries to readUint16, it returns garbage.

The attribute is generated in Reflection.Emit using new CustomAttributeBuilder(constructor, new byte[0]).

Did not check the spec on validity, but the assembly passes peverify.

Cheers

leppie
