### PR TITLE
Add support for reading the new target platforms in C# 5: ARM and AnyCPU32BitPreferred

### DIFF
--- a/Mono.Cecil.PE/ImageReader.cs
+++ b/Mono.Cecil.PE/ImageReader.cs
@@ -118,6 +118,8 @@ namespace Mono.Cecil.PE {
 				return TargetArchitecture.AMD64;
 			case 0x0200:
 				return TargetArchitecture.IA64;
+			case 0x01c4:
+				return TargetArchitecture.ARMv7;
 			}
 
 			throw new NotSupportedException ();

--- a/Mono.Cecil/ModuleKind.cs
+++ b/Mono.Cecil/ModuleKind.cs
@@ -41,6 +41,7 @@ namespace Mono.Cecil {
 		I386,
 		AMD64,
 		IA64,
+		ARMv7,
 	}
 
 	[Flags]
@@ -48,5 +49,6 @@ namespace Mono.Cecil {
 		ILOnly = 1,
 		Required32Bit = 2,
 		StrongNameSigned = 8,
+		Preferred32Bit = 0x00020000,
 	}
 }


### PR DESCRIPTION
This patch does not include support for writing ARM binaries.
