### PR TITLE
Add enum value and properties for Windows Runtime.

### DIFF
--- a/Mono.Cecil/AssemblyFlags.cs
+++ b/Mono.Cecil/AssemblyFlags.cs
@@ -35,6 +35,7 @@ namespace Mono.Cecil {
 		PublicKey					 	= 0x0001,
 		SideBySideCompatible			= 0x0000,
 		Retargetable					= 0x0100,
+		WindowsRuntime					= 0x0200,
 		DisableJITCompileOptimizer		= 0x4000,
 		EnableJITCompileTracking		= 0x8000,
 	}

--- a/Mono.Cecil/AssemblyNameReference.cs
+++ b/Mono.Cecil/AssemblyNameReference.cs
@@ -92,6 +92,11 @@ namespace Mono.Cecil {
 			set { attributes = attributes.SetAttributes ((uint) AssemblyAttributes.Retargetable, value); }
 		}
 
+		public bool IsWindowsRuntime {
+			get { return attributes.GetAttributes ((uint) AssemblyAttributes.WindowsRuntime); }
+			set { attributes = attributes.SetAttributes ((uint) AssemblyAttributes.WindowsRuntime, value); }
+		}
+
 		public byte [] PublicKey {
 			get { return public_key; }
 			set {

--- a/Mono.Cecil/TypeAttributes.cs
+++ b/Mono.Cecil/TypeAttributes.cs
@@ -62,6 +62,7 @@ namespace Mono.Cecil {
 		// Implementation attributes
 		Import				= 0x00001000,	// Class/Interface is imported
 		Serializable		= 0x00002000,	// Class is serializable
+		WindowsRuntime		= 0x00004000,	// Windows Runtime type
 
 		// String formatting attributes
 		StringFormatMask	= 0x00030000,	// Use this mask to retrieve string information for native interop

--- a/Mono.Cecil/TypeDefinition.cs
+++ b/Mono.Cecil/TypeDefinition.cs
@@ -389,6 +389,11 @@ namespace Mono.Cecil {
 			set { attributes = attributes.SetAttributes ((uint) TypeAttributes.Serializable, value); }
 		}
 
+		public bool IsWindowsRuntime {
+			get { return attributes.GetAttributes ((uint) TypeAttributes.WindowsRuntime); }
+			set { attributes = attributes.SetAttributes ((uint) TypeAttributes.WindowsRuntime, value); }
+		}
+
 		public bool IsAnsiClass {
 			get { return attributes.GetMaskedAttributes ((uint) TypeAttributes.StringFormatMask, (uint) TypeAttributes.AnsiClass); }
 			set { attributes = attributes.SetMaskedAttributes ((uint) TypeAttributes.StringFormatMask, (uint) TypeAttributes.AnsiClass, value); }


### PR DESCRIPTION
This corresponds to the 'windowsruntime' IL keyword. (tested VS11 Beta's ILDasm)
