### PR TITLE
adjust AssemblyResolver to ReaderParameters for SubModuleDefs

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -552,6 +552,7 @@ namespace Mono.Cecil {
 				var parameters = new ReaderParameters {
 					ReadingMode = module.ReadingMode,
 					SymbolReaderProvider = module.SymbolReaderProvider,
+					AssemblyResolver = module.AssemblyResolver
 				};
 
 				modules.Add (ModuleDefinition.ReadModule (


### PR DESCRIPTION
If you spec an AssemblyResolver in you ReaderParameters when calling read for an ModuleDef/ AssemblyDef the SubModules are still created with an new AssemblyResolver.
I changed that with the changes of this commit.
If that isnt correct I´d like to do that just under some a condition so that you can enable such a behavior/ or impl. something like an SubModuleReaderParametersProvider or that the ReaderParameters have a method create ReaderParameters for SubModules or something like that.
