### PR TITLE
put Microsoft.Cci.Pdb in Mono.Cecil.Cci.Pdb

### DIFF
--- a/Mono.Cecil.sln
+++ b/Mono.Cecil.sln
@@ -1,5 +1,5 @@
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{74E5ECE0-06B4-401C-AEBA-E8DD53E17943}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Symbols", "Symbols", "{929D5B3B-E29A-40CC-93D8-0FF43A6F9FA1}"
@@ -21,6 +21,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Cecil.Rocks.Tests", "rocks\Test\Mono.Cecil.Rocks.Tests.csproj", "{C6CFD7E1-B855-44DC-B4CE-9CD72984AF52}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Cecil.Rocks", "rocks\Mono.Cecil.Rocks.csproj", "{FBC6DD59-D09D-499C-B03C-99C1C78FF2AC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Cecil.Cci.Pdb", "symbols\pdb\Mono.Cecil.Cci.Pdb.csproj", "{CC988FE0-C12D-4678-A02C-1FD84A8261A2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -182,6 +184,26 @@ Global
 		{FBC6DD59-D09D-499C-B03C-99C1C78FF2AC}.winphone_Debug|Any CPU.Build.0 = winphone_Debug|Any CPU
 		{FBC6DD59-D09D-499C-B03C-99C1C78FF2AC}.winphone_Release|Any CPU.ActiveCfg = winphone_Release|Any CPU
 		{FBC6DD59-D09D-499C-B03C-99C1C78FF2AC}.winphone_Release|Any CPU.Build.0 = winphone_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_2_0_Debug|Any CPU.ActiveCfg = net_2_0_Debug|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_2_0_Debug|Any CPU.Build.0 = net_2_0_Debug|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_2_0_Release|Any CPU.ActiveCfg = net_2_0_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_2_0_Release|Any CPU.Build.0 = net_2_0_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_3_5_Debug|Any CPU.ActiveCfg = net_3_5_Debug|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_3_5_Debug|Any CPU.Build.0 = net_3_5_Debug|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_3_5_Release|Any CPU.ActiveCfg = net_3_5_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_3_5_Release|Any CPU.Build.0 = net_3_5_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_4_0_Debug|Any CPU.ActiveCfg = net_4_0_Debug|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_4_0_Debug|Any CPU.Build.0 = net_4_0_Debug|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_4_0_Release|Any CPU.ActiveCfg = net_4_0_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.net_4_0_Release|Any CPU.Build.0 = net_4_0_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.silverlight_Debug|Any CPU.ActiveCfg = net_4_0_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.silverlight_Debug|Any CPU.Build.0 = net_4_0_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.silverlight_Release|Any CPU.ActiveCfg = net_4_0_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.silverlight_Release|Any CPU.Build.0 = net_4_0_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.winphone_Debug|Any CPU.ActiveCfg = net_4_0_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.winphone_Debug|Any CPU.Build.0 = net_4_0_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.winphone_Release|Any CPU.ActiveCfg = net_4_0_Release|Any CPU
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2}.winphone_Release|Any CPU.Build.0 = net_4_0_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -193,5 +215,6 @@ Global
 		{C6CFD7E1-B855-44DC-B4CE-9CD72984AF52} = {74E5ECE0-06B4-401C-AEBA-E8DD53E17943}
 		{8559DD7F-A16F-46D0-A05A-9139FAEBA8FD} = {929D5B3B-E29A-40CC-93D8-0FF43A6F9FA1}
 		{63E6915C-7EA4-4D76-AB28-0D7191EEA626} = {929D5B3B-E29A-40CC-93D8-0FF43A6F9FA1}
+		{CC988FE0-C12D-4678-A02C-1FD84A8261A2} = {929D5B3B-E29A-40CC-93D8-0FF43A6F9FA1}
 	EndGlobalSection
 EndGlobal

--- a/symbols/pdb/Microsoft.Cci.Pdb/PdbFile.cs
+++ b/symbols/pdb/Microsoft.Cci.Pdb/PdbFile.cs
@@ -15,7 +15,7 @@ using System.IO;
 using System.Diagnostics.SymbolStore;
 
 namespace Microsoft.Cci.Pdb {
-  internal class PdbFile {
+  public class PdbFile {
     private PdbFile()   // This class can't be instantiated.
     {
     }
@@ -337,7 +337,7 @@ namespace Microsoft.Cci.Pdb {
       bits.Position = end;
     }
 
-    internal static PdbFunction[] LoadFunctions(Stream read, out Dictionary<uint, PdbTokenLine> tokenToSourceMapping, out string sourceServerData, out int age, out Guid guid) {
+    public static PdbFunction[] LoadFunctions(Stream read, out Dictionary<uint, PdbTokenLine> tokenToSourceMapping, out string sourceServerData, out int age, out Guid guid) {
       tokenToSourceMapping = new Dictionary<uint, PdbTokenLine>();
       BitAccess bits = new BitAccess(512 * 1024);
       PdbFileHeader head = new PdbFileHeader(read, bits);

--- a/symbols/pdb/Microsoft.Cci.Pdb/PdbFunction.cs
+++ b/symbols/pdb/Microsoft.Cci.Pdb/PdbFunction.cs
@@ -13,14 +13,14 @@ using System.Collections;
 using System.Collections.Generic;
 
 namespace Microsoft.Cci.Pdb {
-  internal class PdbFunction {
+  public class PdbFunction {
     static internal readonly Guid msilMetaData = new Guid(0xc6ea3fc9, 0x59b3, 0x49d6, 0xbc, 0x25,
                                                         0x09, 0x02, 0xbb, 0xab, 0xb4, 0x60);
     static internal readonly IComparer byAddress = new PdbFunctionsByAddress();
     static internal readonly IComparer byAddressAndToken = new PdbFunctionsByAddressAndToken();
     //static internal readonly IComparer byToken = new PdbFunctionsByToken();
 
-    internal uint token;
+    public uint token;
     internal uint slotToken;
     internal uint tokenOfMethodWhoseUsingInfoAppliesToThisMethod;
     //internal string name;
@@ -32,11 +32,11 @@ namespace Microsoft.Cci.Pdb {
     //internal uint length;
 
     //internal byte[] metadata;
-    internal PdbScope[] scopes;
+    public PdbScope[] scopes;
     internal PdbSlot[] slots;
     internal PdbConstant[] constants;
     internal string[] usedNamespaces;
-    internal PdbLines[] lines;
+    public PdbLines[] lines;
     internal ushort[]/*?*/ usingCounts;
     internal IEnumerable<INamespaceScope>/*?*/ namespaceScopes;
     internal string/*?*/ iteratorClass;

--- a/symbols/pdb/Microsoft.Cci.Pdb/PdbLine.cs
+++ b/symbols/pdb/Microsoft.Cci.Pdb/PdbLine.cs
@@ -11,12 +11,12 @@
 using System;
 
 namespace Microsoft.Cci.Pdb {
-  internal struct PdbLine {
-    internal uint offset;
-    internal uint lineBegin;
-    internal uint lineEnd;
-    internal ushort colBegin;
-    internal ushort colEnd;
+  public struct PdbLine {
+    public uint offset;
+    public uint lineBegin;
+    public uint lineEnd;
+    public ushort colBegin;
+    public ushort colEnd;
 
     internal PdbLine(uint offset, uint lineBegin, ushort colBegin, uint lineEnd, ushort colEnd) {
       this.offset = offset;

--- a/symbols/pdb/Microsoft.Cci.Pdb/PdbLines.cs
+++ b/symbols/pdb/Microsoft.Cci.Pdb/PdbLines.cs
@@ -11,9 +11,9 @@
 using System;
 
 namespace Microsoft.Cci.Pdb {
-  internal class PdbLines {
-    internal PdbSource file;
-    internal PdbLine[] lines;
+  public class PdbLines {
+    public PdbSource file;
+    public PdbLine[] lines;
 
     internal PdbLines(PdbSource file, uint count) {
       this.file = file;

--- a/symbols/pdb/Microsoft.Cci.Pdb/PdbScope.cs
+++ b/symbols/pdb/Microsoft.Cci.Pdb/PdbScope.cs
@@ -11,10 +11,10 @@
 using System;
 
 namespace Microsoft.Cci.Pdb {
-  internal class PdbScope {
+  public class PdbScope {
     internal PdbConstant[] constants;
-    internal PdbSlot[] slots;
-    internal PdbScope[] scopes;
+    public PdbSlot[] slots;
+    public PdbScope[] scopes;
     internal string[] usedNamespaces;
 
     //internal uint segment;

--- a/symbols/pdb/Microsoft.Cci.Pdb/PdbSlot.cs
+++ b/symbols/pdb/Microsoft.Cci.Pdb/PdbSlot.cs
@@ -11,10 +11,10 @@
 using System;
 
 namespace Microsoft.Cci.Pdb {
-  internal class PdbSlot {
-    internal uint slot;
+  public class PdbSlot {
+    public uint slot;
     internal uint typeToken;
-    internal string name;
+    public string name;
     internal ushort flags;
     //internal uint segment;
     //internal uint address;

--- a/symbols/pdb/Microsoft.Cci.Pdb/PdbSource.cs
+++ b/symbols/pdb/Microsoft.Cci.Pdb/PdbSource.cs
@@ -11,12 +11,12 @@
 using System;
 
 namespace Microsoft.Cci.Pdb {
-  internal class PdbSource {
+  public class PdbSource {
     //internal uint index;
-    internal string name;
-    internal Guid doctype;
-    internal Guid language;
-    internal Guid vendor;
+    public string name;
+    public Guid doctype;
+    public Guid language;
+    public Guid vendor;
 
     internal PdbSource(/*uint index, */string name, Guid doctype, Guid language, Guid vendor) {
       //this.index = index;

--- a/symbols/pdb/Microsoft.Cci.Pdb/PdbTokenLine.cs
+++ b/symbols/pdb/Microsoft.Cci.Pdb/PdbTokenLine.cs
@@ -11,7 +11,7 @@
 using System;
 
 namespace Microsoft.Cci.Pdb {
-  internal class PdbTokenLine {
+  public class PdbTokenLine {
     internal uint token;
     internal uint file_id;
     internal uint line;

--- a/symbols/pdb/Mono.Cecil.Cci.Pdb.csproj
+++ b/symbols/pdb/Mono.Cecil.Cci.Pdb.csproj
@@ -1,0 +1,118 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">net_4_0_Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{CC988FE0-C12D-4678-A02C-1FD84A8261A2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Mono.Cecil.Cci.Pdb</RootNamespace>
+    <AssemblyName>Mono.Cecil.Cci.Pdb</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\mono.snk</AssemblyOriginatorKeyFile>
+    <NoWarn>0649</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'net_2_0_Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\net_2_0_Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'net_2_0_Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\net_2_0_Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'net_3_5_Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\net_3_5_Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NET_3_5</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'net_3_5_Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\net_3_5_Release\</OutputPath>
+    <DefineConstants>TRACE;NET_3_5</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'net_4_0_Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\net_4_0_Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NET_3_5;NET_4_0</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'net_4_0_Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\net_4_0_Release\</OutputPath>
+    <DefineConstants>TRACE;NET_3_5;NET_4_0</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' != 'v2.0' ">
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Microsoft.Cci.Pdb\BitAccess.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\BitSet.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\CvInfo.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\DataStream.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\DbiDbgHdr.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\DbiHeader.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\DbiModuleInfo.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\DbiSecCon.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\Interfaces.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\IntHashTable.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\MsfDirectory.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbConstant.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbDebugException.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbException.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbFile.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbFileHeader.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbFunction.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbLine.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbLines.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbReader.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbScope.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbSlot.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbSource.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\PdbTokenLine.cs" />
+    <Compile Include="Microsoft.Cci.Pdb\SourceLocationProvider.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/symbols/pdb/Mono.Cecil.Pdb.csproj
+++ b/symbols/pdb/Mono.Cecil.Pdb.csproj
@@ -83,35 +83,12 @@
       <Project>{D68133BD-1E63-496E-9EDE-4FBDBF77B486}</Project>
       <Name>Mono.Cecil</Name>
     </ProjectReference>
+    <ProjectReference Include="Mono.Cecil.Cci.Pdb.csproj">
+      <Project>{cc988fe0-c12d-4678-a02c-1fd84a8261a2}</Project>
+      <Name>Mono.Cecil.Cci.Pdb</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Microsoft.Cci.Pdb\BitAccess.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\BitSet.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\CvInfo.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\DataStream.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\DbiDbgHdr.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\DbiHeader.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\DbiModuleInfo.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\DbiSecCon.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\Interfaces.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\IntHashTable.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\MsfDirectory.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbConstant.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbDebugException.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbException.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbFile.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbFileHeader.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbFunction.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbLine.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbLines.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbReader.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbScope.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbSlot.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbSource.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\PdbTokenLine.cs" />
-    <Compile Include="Microsoft.Cci.Pdb\SourceLocationProvider.cs">
-      <SubType>Code</SubType>
-    </Compile>
     <Compile Include="Mono.Cecil.Pdb\AssemblyInfo.cs" />
     <Compile Include="Mono.Cecil.Pdb\ISymUnmanagedDocumentWriter.cs" />
     <Compile Include="Mono.Cecil.Pdb\ISymUnmanagedWriter2.cs" />


### PR DESCRIPTION
I separated out that Microsoft.Cci.Pdb namespace into its own dll and named it Mono.Cecil.Cci.Pdb. I made anything public that was need to build. Having these items public is useful. http://blog.ctaggart.com/2013/03/assembly-to-pdb-to-source-files.html
