### PR TITLE
Add a Scope property to ResolutionException.

### DIFF
--- a/Mono.Cecil/MetadataResolver.cs
+++ b/Mono.Cecil/MetadataResolver.cs
@@ -52,15 +52,26 @@ namespace Mono.Cecil {
 	public class ResolutionException : Exception {
 
 		readonly MemberReference member;
+		readonly IMetadataScope scope;
 
 		public MemberReference Member {
 			get { return member; }
 		}
 
+		public IMetadataScope Scope {
+			get { return scope; }
+		}
+
 		public ResolutionException (MemberReference member)
-			: base ("Failed to resolve " + member.FullName)
+			: this (member, null)
+		{
+		}
+
+		public ResolutionException (MemberReference member, IMetadataScope scope)
+			: base ("Failed to resolve " + member.FullName + (scope != null ? " from " + scope.Name : string.Empty))
 		{
 			this.member = member;
+			this.scope = scope;
 		}
 
 #if !SILVERLIGHT && !CF

--- a/Mono.Cecil/TypeReference.cs
+++ b/Mono.Cecil/TypeReference.cs
@@ -331,7 +331,7 @@ namespace Mono.Cecil {
 		{
 			var type = self.Resolve ();
 			if (type == null)
-				throw new ResolutionException (self);
+				throw new ResolutionException (self, self.Scope);
 
 			return type;
 		}


### PR DESCRIPTION
`ResolutionException` is currently only used for `TypeReference`s so it
will always be non-null, but if/when `ResolutionException` is used for
other things -- such as `FieldReference`s -- it can be null.

This could be retrieved by casting the `Member` property, but I think
this is a much less hacky approach.
