### PR TITLE
Avoid self reference in ImportScope.

### DIFF
--- a/Mono.Cecil/Import.cs
+++ b/Mono.Cecil/Import.cs
@@ -466,6 +466,7 @@ namespace Mono.Cecil {
 			case MetadataScopeType.AssemblyNameReference:
 				return ImportAssemblyName ((AssemblyNameReference) scope);
 			case MetadataScopeType.ModuleDefinition:
+				if (scope == module) return scope;
 				return ImportAssemblyName (((ModuleDefinition) scope).Assembly.Name);
 			case MetadataScopeType.ModuleReference:
 				throw new NotImplementedException ();


### PR DESCRIPTION
ImportScope now checks before returning new scope that the old scope is not the same as the Import.module. If it is the same it returns the Import.module so a self reference can be avoided.
