### PR TITLE
If needed unescape a type AssemblyQualifiedName

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -3099,9 +3099,29 @@ namespace Mono.Cecil {
 			}
 		}
 
+		string UnescapeTypeName (string name)
+		{
+			StringBuilder sb = new StringBuilder (name.Length);
+			for (int i = 0; i < name.Length; i++) {
+				char c = name [i];
+				if (name [i] == '\\') {
+					if ((i < name.Length - 1) && (name [i + 1] == '\\')) {
+						sb.Append (c);
+						i++;
+					}
+				} else {
+					sb.Append (c);
+				}
+			}
+			return sb.ToString ();
+		}
+
 		public TypeReference ReadTypeReference ()
 		{
-			return TypeParser.ParseType (reader.module, ReadUTF8String ());
+			string s = ReadUTF8String ();
+			if (s.IndexOf ('\\') != -1)
+				s = UnescapeTypeName (s);
+			return TypeParser.ParseType (reader.module, s);
 		}
 
 		object ReadCustomAttributeEnum (TypeReference enum_type)


### PR DESCRIPTION
A type AssemblyQualifiedName need to be un-escaped when it contains the `\` character. That's pretty uncommon but looks like:

```
@"TypeA`2[[System.Collections.Generic.List`1[[TypeB, AssemblyA, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\]\], mscorlib, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e][TypeC, AssemblyA, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]], TypeD, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
```

[1] http://msdn.microsoft.com/en-us/library/system.type.assemblyqualifiedname.aspx
