### PR TITLE
Use the original stacktrace, not a new one.

### DIFF
--- a/Mono.Security.Cryptography/CryptoConvert.cs
+++ b/Mono.Security.Cryptography/CryptoConvert.cs
@@ -143,6 +143,7 @@ namespace Mono.Security.Cryptography {
 				// this may cause problem when this code is run under
 				// the SYSTEM identity on Windows (e.g. ASP.NET). See
 				// http://bugzilla.ximian.com/show_bug.cgi?id=77559
+				bool throws = false;
 				try {
 					CspParameters csp = new CspParameters ();
 					csp.Flags = CspProviderFlags.UseMachineKeyStore;
@@ -150,8 +151,12 @@ namespace Mono.Security.Cryptography {
 					rsa.ImportParameters (rsap);
 				}
 				catch {
-					// rethrow original, not the later, exception if this fails
-					throw ce;
+					throws = true;
+				}
+
+				if (throws) {
+					// rethrow original, not the latter, exception if this fails
+					throw;
 				}
 			}
 			return rsa;


### PR DESCRIPTION
Throwing that specific exception will change the stacktrace to point at the new exception point, instead of the original.

I'm not sure if it was intended or not.
