### PR TITLE
Helpers to allow getting referencies and definitions

### DIFF
--- a/rocks/Mono.Cecil.Rocks.csproj
+++ b/rocks/Mono.Cecil.Rocks.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">net_4_0_Debug</Configuration>
@@ -103,10 +103,15 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Mono.Cecil.Rocks\AssemblyInfo.cs" />
+    <Compile Include="Mono.Cecil.Rocks\FieldRef.cs" />
+    <Compile Include="Mono.Cecil.Rocks\MethodDef.cs" />
     <Compile Include="Mono.Cecil.Rocks\MethodDefinitionRocks.cs" />
+    <Compile Include="Mono.Cecil.Rocks\MethodRef.cs" />
     <Compile Include="Mono.Cecil.Rocks\SecurityDeclarationRocks.cs" />
     <Compile Include="Mono.Cecil.Rocks\MethodBodyRocks.cs" />
     <Compile Include="Mono.Cecil.Rocks\ILParser.cs" />
+    <Compile Include="Mono.Cecil.Rocks\TypeDef.cs" />
+    <Compile Include="Mono.Cecil.Rocks\TypeRef.cs" />
     <Compile Include="Mono.Cecil.Rocks\TypeReferenceRocks.cs" />
     <Compile Include="Mono.Cecil.Rocks\Functional.cs" />
     <Compile Include="Mono.Cecil.Rocks\ModuleDefinitionRocks.cs" />

--- a/rocks/Mono.Cecil.Rocks/FieldRef.cs
+++ b/rocks/Mono.Cecil.Rocks/FieldRef.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+using System.Reflection;
+
+namespace Mono.Cecil.Rocks
+{
+    public static class FieldRef
+    {
+        public static FieldReference Of(string name, TypeReference ref_type, ModuleDefinition context)
+        { 
+            var def_field = ref_type.Resolve().Fields.FirstOrDefault(field => field.Name == name);
+            return context.Import(def_field);
+        }
+
+        public static FieldReference Of(FieldInfo field, ModuleDefinition context)
+        {
+            return context.Import(field);
+        }
+    }
+}
+

--- a/rocks/Mono.Cecil.Rocks/MethodDef.cs
+++ b/rocks/Mono.Cecil.Rocks/MethodDef.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Reflection;
+using Mono.Cecil.Cil;
+using System.Collections.Generic;
+
+namespace Mono.Cecil.Rocks
+{
+    /// <summary>
+    /// Should be used for getting Mono::Cecil MethodDefinition by runtime MethodInfo (Action or Func actually)
+    /// </summary>
+	public static class MethodDef
+	{
+        public static MethodDefinition Of(ModuleDefinition module, Action method)
+        {
+            return ResolveMethod(module, method.Method);
+		}
+		
+        public static MethodDefinition Of<T1>(ModuleDefinition module, Action<T1> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+
+        public static MethodDefinition Of<T1, T2>(ModuleDefinition module, Action<T1, T2> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+		
+        public static MethodDefinition Of<T1, T2, T3>(ModuleDefinition module, Action<T1, T2, T3> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+
+        public static MethodDefinition Of<T1, T2, T3, T4>(ModuleDefinition module, Action<T1, T2, T3, T4> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+
+        public static MethodDefinition Of<T1, T2, T3, T4, T5>(ModuleDefinition module, Action<T1, T2, T3, T4, T5> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+
+        public static MethodDefinition Of<T1, T2, T3, T4, T5, T6>(ModuleDefinition module, Action<T1, T2, T3, T4, T5, T6> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+
+        public static MethodDefinition Of<T1, T2, T3, T4, T5, T6, T7>(ModuleDefinition module, Action<T1, T2, T3, T4, T5, T6, T7> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+
+        public static MethodDefinition Of<T1, T2, T3, T4, T5, T6, T7, T8>(ModuleDefinition module, Action<T1, T2, T3, T4, T5, T6, T7, T8> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+
+        public static MethodDefinition Of<T1>(ModuleDefinition module, Func<T1> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+		
+        public static MethodDefinition Of<T1, T2>(ModuleDefinition module, Func<T1, T2> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+		
+        public static MethodDefinition Of<T1, T2, T3>(ModuleDefinition module, Func<T1, T2, T3> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+		
+        public static MethodDefinition Of<T1, T2, T3, T4>(ModuleDefinition module, Func<T1, T2, T3, T4> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+		
+        public static MethodDefinition Of<T1, T2, T3, T4, T5>(ModuleDefinition module, Func<T1, T2, T3, T4, T5> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+		
+        public static MethodDefinition Of<T1, T2, T3, T4, T5, T6>(ModuleDefinition module, Func<T1, T2, T3, T4, T5, T6> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+		
+        public static MethodDefinition Of<T1, T2, T3, T4, T5, T6, T7>(ModuleDefinition module, Func<T1, T2, T3, T4, T5, T6, T7> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+		
+        public static MethodDefinition Of<T1, T2, T3, T4, T5, T6, T7, T8>(ModuleDefinition module, Func<T1, T2, T3, T4, T5, T6, T7, T8> method)
+		{
+            return ResolveMethod(module, method.Method);
+		}
+
+        private static MethodDefinition ResolveMethod(ModuleDefinition module, MethodInfo method)
+		{
+            return module.Import(method).Resolve();
+        }
+	}
+}

--- a/rocks/Mono.Cecil.Rocks/MethodRef.cs
+++ b/rocks/Mono.Cecil.Rocks/MethodRef.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Reflection;
+
+namespace Mono.Cecil.Rocks
+{	
+	public static class MethodRef
+	{
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of(ModuleDefinition context, Action method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1>(ModuleDefinition context, Action<T1> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2>(ModuleDefinition context, Action<T1, T2> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3>(ModuleDefinition context, Action<T1, T2, T3> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3, T4>(ModuleDefinition context, Action<T1, T2, T3, T4> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3, T4, T5>(ModuleDefinition context, Action<T1, T2, T3, T4, T5> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3, T4, T5, T6>(ModuleDefinition context, Action<T1, T2, T3, T4, T5, T6> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3, T4, T5, T6, T7>(ModuleDefinition context, Action<T1, T2, T3, T4, T5, T6, T7> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3, T4, T5, T6, T7, T8>(ModuleDefinition context, Action<T1, T2, T3, T4, T5, T6, T7, T8> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1>(ModuleDefinition context, Func<T1> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2>(ModuleDefinition context, Func<T1, T2> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3>(ModuleDefinition context, Func<T1, T2, T3> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3, T4>(ModuleDefinition context, Func<T1, T2, T3, T4> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3, T4, T5>(ModuleDefinition context, Func<T1, T2, T3, T4, T5> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3, T4, T5, T6>(ModuleDefinition context, Func<T1, T2, T3, T4, T5, T6> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3, T4, T5, T6, T7>(ModuleDefinition context, Func<T1, T2, T3, T4, T5, T6, T7> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        public static MethodReference Of<T1, T2, T3, T4, T5, T6, T7, T8>(ModuleDefinition context, Func<T1, T2, T3, T4, T5, T6, T7, T8> method)
+		{
+			return ResolveMethod(method.Method, context);
+		}
+		
+        /// <summary>
+        /// Imports method, covered by <paramref name="method"> parameter to be used in module <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">Context to import to</param>
+        /// <param name="method">Method to be imported</param>
+        private static MethodReference ResolveMethod(MethodInfo method, ModuleDefinition context)
+		{
+			return context.Import(method);
+		}		
+	}
+}
+

--- a/rocks/Mono.Cecil.Rocks/TypeDef.cs
+++ b/rocks/Mono.Cecil.Rocks/TypeDef.cs
@@ -1,0 +1,28 @@
+using Mono.Cecil.Cil;
+
+namespace Mono.Cecil.Rocks
+{
+    public static class TypeDef
+    {
+        public static TypeDefinition Of(FieldReference field)
+        {
+            return field.FieldType.Resolve();
+        }
+        
+        public static TypeDefinition Of(ParameterReference param)
+        {
+            return param.ParameterType.Resolve();
+        }
+        
+        public static TypeDefinition Of(VariableReference variable)
+        {
+            return variable.VariableType.Resolve();
+        }
+        
+        public static TypeDefinition Of(TypeReference type)
+        {
+            return type.Resolve();
+        }
+    }
+}
+

--- a/rocks/Mono.Cecil.Rocks/TypeRef.cs
+++ b/rocks/Mono.Cecil.Rocks/TypeRef.cs
@@ -1,0 +1,39 @@
+using Mono.Cecil.Cil;
+using System;
+
+namespace Mono.Cecil.Rocks
+{
+    public static class TypeRef
+    {
+        public static TypeReference Of<T>(ModuleDefinition context)
+        {
+            return context.Import(typeof(T));
+        }
+        
+        public static TypeReference Of(Type type, ModuleDefinition context)
+        {
+            return context.Import(type);
+        }
+
+        public static TypeReference Of(FieldReference field, ModuleDefinition context = null)
+        {
+            return context == null ? field.FieldType : context.Import(field.FieldType);
+        }
+        
+        public static TypeReference Of(ParameterReference param, ModuleDefinition context = null)
+        {
+            return context == null ? param.ParameterType : context.Import(param.ParameterType);
+        }
+        
+        public static TypeReference Of(VariableReference variable, ModuleDefinition context = null)
+        {
+            return context == null ? variable.VariableType : context.Import(variable.VariableType);
+        }
+        
+        public static TypeReference Of(TypeReference type, ModuleDefinition context = null)
+        {
+            return context == null ? type : context.Import(type);
+        }
+    }
+}
+


### PR DESCRIPTION
Allows to write like following:

TypeReference type1_ref = TypeRef.Of<Thread>(module);
TypeDefinition type1_def = TypeDef.Of(field_ref);
TypeDefinition type2_def = TypeDef.Of(variable_ref);
TypeDefinition type3_def = TypeDef.Of(parameter_ref);

MethodReference method1_ref = MethodRef.Of(module, Thread.BeginCriticalRegion);
MethodDefinition method2_def = MethodDef.Of(module, Thread.BeginCriticalRegion);
