### PR TITLE
Add support for rewriting source path location stored in PDB/MDB

### DIFF
--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -268,7 +268,7 @@ namespace Mono.Cecil.Cil {
 
 	public interface ISymbolWriterProvider {
 
-		ISymbolWriter GetSymbolWriter (ModuleDefinition module, string fileName, Func<string, string> sourcePathRewriter);
+		ISymbolWriter GetSymbolWriter (ModuleDefinition module, string fileName, SourcePathRewriterDelegate sourcePathRewriter);
 	}
 
 #endif

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -135,7 +135,7 @@ namespace Mono.Cecil {
 			});
 		}
 
-		static ISymbolWriter GetSymbolWriter(ModuleDefinition module, string fq_name, ISymbolWriterProvider symbol_writer_provider, Func<string, string> sourcePathRewriter)
+		static ISymbolWriter GetSymbolWriter(ModuleDefinition module, string fq_name, ISymbolWriterProvider symbol_writer_provider, SourcePathRewriterDelegate sourcePathRewriter)
 		{
 			if (symbol_writer_provider == null)
 				return null;

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -157,9 +157,16 @@ namespace Mono.Cecil {
 		}
 	}
 
+	/// <summary>
+	/// Delegate used to rewrite sourcepath location stored in PDB/MDB.
+	/// </summary>
+	/// <param name="sourcePath">The source path.</param>
+	/// <returns>The sourcepath rewrited.</returns>
+	public delegate string SourcePathRewriterDelegate(string sourcePath);
+
 	public sealed class WriterParameters
 	{
-		Func<string, string> sourcePathRewriter;
+		SourcePathRewriterDelegate sourcePathRewriter;
 		Stream symbol_stream;
 		ISymbolWriterProvider symbol_writer_provider;
 		bool write_symbols;
@@ -181,7 +188,7 @@ namespace Mono.Cecil {
 			set { write_symbols = value; }
 		}
 
-		public Func<string, string> SourcePathRewriter
+		public SourcePathRewriterDelegate SourcePathRewriter
 		{
 			get { return sourcePathRewriter; }
 			set { sourcePathRewriter = value; }

--- a/symbols/mdb/Mono.Cecil.Mdb/MdbWriter.cs
+++ b/symbols/mdb/Mono.Cecil.Mdb/MdbWriter.cs
@@ -39,7 +39,7 @@ namespace Mono.Cecil.Mdb {
 #if !READ_ONLY
 	public class MdbWriterProvider : ISymbolWriterProvider {
 
-		public ISymbolWriter GetSymbolWriter (ModuleDefinition module, string fileName, Func<string, string> sourcePathRewriter)
+		public ISymbolWriter GetSymbolWriter (ModuleDefinition module, string fileName, SourcePathRewriterDelegate sourcePathRewriter)
 		{
 			return new MdbWriter (module.Mvid, fileName, sourcePathRewriter);
 		}
@@ -50,9 +50,9 @@ namespace Mono.Cecil.Mdb {
 		readonly Guid mvid;
 		readonly MonoSymbolWriter writer;
 		readonly Dictionary<string, SourceFile> source_files;
-		readonly Func<string, string> sourcePathRewriter;
+		readonly SourcePathRewriterDelegate sourcePathRewriter;
 
-		public MdbWriter(Guid mvid, string assembly, Func<string, string> sourcePathRewriter)
+		public MdbWriter(Guid mvid, string assembly, SourcePathRewriterDelegate sourcePathRewriter)
 		{
 			this.mvid = mvid;
 			this.sourcePathRewriter = sourcePathRewriter;

--- a/symbols/pdb/Mono.Cecil.Pdb/PdbHelper.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/PdbHelper.cs
@@ -73,7 +73,7 @@ namespace Mono.Cecil.Pdb {
 
 	public class PdbWriterProvider : ISymbolWriterProvider {
 
-		public ISymbolWriter GetSymbolWriter (ModuleDefinition module, string fileName, Func<string, string> sourcePathRewriter)
+		public ISymbolWriter GetSymbolWriter (ModuleDefinition module, string fileName, SourcePathRewriterDelegate sourcePathRewriter)
 		{
 			return new PdbWriter (module, PdbHelper.CreateWriter (module, PdbHelper.GetPdbFileName (fileName)), sourcePathRewriter);
 		}

--- a/symbols/pdb/Mono.Cecil.Pdb/PdbWriter.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/PdbWriter.cs
@@ -42,9 +42,9 @@ namespace Mono.Cecil.Pdb {
 		readonly ModuleDefinition module;
 		readonly SymWriter writer;
 		readonly Dictionary<string, SymDocumentWriter> documents;
-		readonly Func<string, string> sourcePathRewriter;
+		readonly SourcePathRewriterDelegate sourcePathRewriter;
 
-		internal PdbWriter (ModuleDefinition module, SymWriter writer, Func<string, string> sourcePathRewriter)
+		internal PdbWriter (ModuleDefinition module, SymWriter writer, SourcePathRewriterDelegate sourcePathRewriter)
 		{
 			this.module = module;
 			this.writer = writer;


### PR DESCRIPTION
Hi there,
This is a small enhancement to allow rewriting of sourcepath location for PDB/MDB before saving them. This is useful when we need to package sources with assemblies and PDBs in a new location on the disk (for example, I'm using it in a nuget package at deploy time).
The changes are small:
- New delegate `string SourcePathRewriterDelegate(string)`
- New property `WriteParameters.SourcePathRewriter`
- Modifed `ISymbolWriterProvider` to pass this new parameters to their implems
- Called from PdbWriter/MdbWriter
