### PR TITLE
MethodDefinitionRocks.GetBaseMethod stops on newslot (virtual new) methods

### DIFF
--- a/rocks/Mono.Cecil.Rocks/MethodDefinitionRocks.cs
+++ b/rocks/Mono.Cecil.Rocks/MethodDefinitionRocks.cs
@@ -41,6 +41,8 @@ namespace Mono.Cecil.Rocks {
 				throw new ArgumentNullException ("self");
 			if (!self.IsVirtual)
 				return self;
+			if (self.IsNewSlot)
+				return self;
 
 			var base_type = ResolveBaseType (self.DeclaringType);
 			while (base_type != null) {

--- a/rocks/Test/Mono.Cecil.Tests/MethodDefinitionRocksTests.cs
+++ b/rocks/Test/Mono.Cecil.Tests/MethodDefinitionRocksTests.cs
@@ -1,53 +1,70 @@
 using System.Linq;
-
+using Mono.Cecil.Rocks;
 using NUnit.Framework;
 
-using Mono.Cecil.Rocks;
-
-namespace Mono.Cecil.Tests {
-
+namespace Mono.Cecil.Tests
+{
 	[TestFixture]
-	public class MethodDefinitionRocksTests : BaseTestFixture {
+	public class MethodDefinitionRocksTests : BaseTestFixture
+	{
+		private abstract class Foo
+		{
+			public abstract void DoFoo();
 
-		abstract class Foo {
-			public abstract void DoFoo ();
+			public abstract void NewFoo();
 		}
 
-		class Bar : Foo {
-			public override void DoFoo ()
+		private class Bar : Foo
+		{
+			public override void DoFoo()
+			{
+			}
+
+			public override void NewFoo()
 			{
 			}
 		}
 
-		class Baz : Bar {
-			public override void DoFoo ()
+		private class Baz : Bar
+		{
+			public override void DoFoo()
+			{
+			}
+
+			// This method does not override but is still virtual
+			public virtual new void NewFoo()
 			{
 			}
 		}
 
 		[Test]
-		public void GetBaseMethod ()
+		public void GetBaseMethod()
 		{
-			var baz = typeof (Baz).ToDefinition ();
-			var baz_dofoo = baz.GetMethod ("DoFoo");
+			var baz = typeof(Baz).ToDefinition();
+			var baz_dofoo = baz.GetMethod("DoFoo");
 
-			var @base = baz_dofoo.GetBaseMethod ();
-			Assert.AreEqual ("Bar", @base.DeclaringType.Name);
+			var @base = baz_dofoo.GetBaseMethod();
+			Assert.AreEqual("Bar", @base.DeclaringType.Name);
 
-			@base = @base.GetBaseMethod ();
-			Assert.AreEqual ("Foo", @base.DeclaringType.Name);
+			@base = @base.GetBaseMethod();
+			Assert.AreEqual("Foo", @base.DeclaringType.Name);
 
-			Assert.AreEqual (@base, @base.GetBaseMethod ());
+			Assert.AreEqual(@base, @base.GetBaseMethod());
+
+			// Stop on virtual new method
+			var baz_newfoo = baz.GetMethod("NewFoo");
+			@base = baz_newfoo.GetBaseMethod();
+			Assert.AreEqual("Baz", @base.DeclaringType.Name);
 		}
 
 		[Test]
-		public void GetOriginalBaseMethod ()
+		public void GetOriginalBaseMethod()
 		{
-			var baz = typeof (Baz).ToDefinition ();
-			var baz_dofoo = baz.GetMethod ("DoFoo");
+			var baz = typeof(Baz).ToDefinition();
+			var baz_dofoo = baz.GetMethod("DoFoo");
 
-			var @base = baz_dofoo.GetOriginalBaseMethod ();
-			Assert.AreEqual ("Foo", @base.DeclaringType.Name);
+			var @base = baz_dofoo.GetOriginalBaseMethod();
+			Assert.AreEqual("Foo", @base.DeclaringType.Name);
 		}
 	}
 }


### PR DESCRIPTION
See our recent Google groups chat. This does good work in my project. I'm sorry for the testcase. I couldn't comply with your formatting, it was automatically changed to something else. So I decided to use my formatting to keep it clean. Also I couldn't run the test because Visual Studio didn't offer it. (I'm still new to unit tests...)
