### PR TITLE
Add a null-check to fix a regression in 4de92b7.

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -3119,7 +3119,7 @@ namespace Mono.Cecil {
 		public TypeReference ReadTypeReference ()
 		{
 			string s = ReadUTF8String ();
-			if (s.IndexOf ('\\') != -1)
+			if (s != null && s.IndexOf ('\\') != -1)
 				s = UnescapeTypeName (s);
 			return TypeParser.ParseType (reader.module, s);
 		}


### PR DESCRIPTION
The regression (NRE) occurs if null is passed as the argument to an
attribute constructor taking a type:

```
[SomeAttribute (null)]
```

where SomeAttribute is:

```
class SomeAttribute : Attribute {
    public SomeAttribute (Type type) {}
}
```
