### PR TITLE
Include namespace in module/type name in pdb (ReSharper navigate to external source)

### DIFF
--- a/symbols/pdb/Mono.Cecil.Pdb/ModuleMetadata.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/ModuleMetadata.cs
@@ -487,7 +487,7 @@ namespace Mono.Cecil.Pdb {
 				return 0;
 			}
 
-			WriteString (type.Name, szTypeDef, cchTypeDef, out pchTypeDef);
+			WriteString (type.IsNested ? type.Name : type.FullName, szTypeDef, cchTypeDef, out pchTypeDef);
 			WriteIntPtr (pdwTypeDefFlags, (uint) type.Attributes);
 			return type.BaseType != null ? type.BaseType.MetadataToken.ToUInt32 () : 0;
 		}


### PR DESCRIPTION
ReSharper uses the fully qualified type name to lookup source files for external assemblies. The current master only writes the short name, which breaks the navigate to source for external assemblies modified by cecil (e.g. Fody).

This fix is from issue #90, which is concerned with both the full namespace in the module name, but also for including debug information for the current scope (e.g. what namespaces are valid, etc.) It looks like a proper fix for the scopes is being worked on in the symbols branch, so this is a cherry pick of @xen2's fix for just the namespace issue, which could be released earlier, and clients such as Fody could pick it up and start generating assemble that work with ReSharper.
