### PR TITLE
Import parameter names

### DIFF
--- a/Mono.Cecil.sln.DotSettings
+++ b/Mono.Cecil.sln.DotSettings
@@ -33,4 +33,5 @@
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File3888B4217219C6449A29410818F112E6/@KeyIndexDefined">True</s:Boolean>
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File3888B4217219C6449A29410818F112E6/RelativePriority/@EntryValue">1</s:Double>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/UnitTesting/SeparateAppDomainPerAssembly/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/UserInterface/ShortcutSchemeName/@EntryValue">None</s:String></wpf:ResourceDictionary>

--- a/Mono.Cecil/Import.cs
+++ b/Mono.Cecil/Import.cs
@@ -384,9 +384,11 @@ namespace Mono.Cecil {
 				var parameters = method.GetParameters ();
 				var reference_parameters = reference.Parameters;
 
-				for (int i = 0; i < parameters.Length; i++)
-					reference_parameters.Add (
-						new ParameterDefinition (ImportType (parameters [i].ParameterType, context)));
+				for (int i = 0; i < parameters.Length; i++) {
+				    var parameter = parameters [i];
+                    reference_parameters.Add(new ParameterDefinition(parameter.Name,
+                        (ParameterAttributes) parameter.Attributes, ImportType(parameter.ParameterType, context)));
+				}
 
 				reference.DeclaringType = declaring_type;
 
@@ -640,9 +642,11 @@ namespace Mono.Cecil {
 				var reference_parameters = reference.Parameters;
 
 				var parameters = method.Parameters;
-				for (int i = 0; i < parameters.Count; i++)
-					reference_parameters.Add (
-						new ParameterDefinition (ImportType (parameters [i].ParameterType, context)));
+				for (int i = 0; i < parameters.Count; i++) {
+				    var parameter = parameters [i];
+				    reference_parameters.Add (new ParameterDefinition (parameter.Name,
+                        parameter.Attributes, ImportType (parameter.ParameterType, context)));
+				}
 
 				return reference;
 			} finally {

--- a/Test/Mono.Cecil.Tests/CompilationService.cs
+++ b/Test/Mono.Cecil.Tests/CompilationService.cs
@@ -259,9 +259,14 @@ namespace Mono.Cecil.Tests {
 				@"Microsoft SDKs\Windows\v7.0A\Bin",
 			};
 
+            var programfilesx86 = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+		    var programfiles = String.IsNullOrEmpty (programfilesx86)
+		        ? Environment.GetFolderPath (Environment.SpecialFolder.ProgramFiles)
+                : programfilesx86;
+
 			foreach (var sdk in sdks) {
-				var exe = Path.Combine (
-					Path.Combine (Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), sdk),
+			    var exe = Path.Combine (
+                    Path.Combine(programfiles, sdk),
 					tool + ".exe");
 
 				if (File.Exists(exe))

--- a/Test/Mono.Cecil.Tests/CompilationService.cs
+++ b/Test/Mono.Cecil.Tests/CompilationService.cs
@@ -192,6 +192,9 @@ namespace Mono.Cecil.Tests {
 			var stdout = new StringWriter ();
 			var stderr = new StringWriter ();
 
+            if (!File.Exists (target))
+                throw new FileNotFoundException(String.Format ("'{0}' was not found.", target), target);
+
 			var process = new Process {
 				StartInfo = new ProcessStartInfo {
 					FileName = target,


### PR DESCRIPTION
When `MetadataImporter.ImportMethod()` imports the parameters of a method, the source parameter's `Name` and `Attributes` are currently ignored, leaving the resulting parameter nameless. This pull request tries to fix this by passing the source parameter's name and attributes to the `ParameterDefinition`'s constructor.