### PR TITLE
Add Resolve() to MemberReference

### DIFF
--- a/Mono.Cecil/EventDefinition.cs
+++ b/Mono.Cecil/EventDefinition.cs
@@ -165,7 +165,7 @@ namespace Mono.Cecil {
 			}
 		}
 
-		public override EventDefinition Resolve ()
+		protected override IMemberDefinition ResolveImpl ()
 		{
 			return this;
 		}

--- a/Mono.Cecil/EventReference.cs
+++ b/Mono.Cecil/EventReference.cs
@@ -52,6 +52,9 @@ namespace Mono.Cecil {
 			event_type = eventType;
 		}
 
-		public abstract EventDefinition Resolve ();
+		public new EventDefinition Resolve ()
+		{
+			return (EventDefinition)base.Resolve();
+		}
 	}
 }

--- a/Mono.Cecil/FieldDefinition.cs
+++ b/Mono.Cecil/FieldDefinition.cs
@@ -257,7 +257,7 @@ namespace Mono.Cecil {
 			this.attributes = (ushort) attributes;
 		}
 
-		public override FieldDefinition Resolve ()
+		protected override IMemberDefinition ResolveImpl ()
 		{
 			return this;
 		}

--- a/Mono.Cecil/FieldReference.cs
+++ b/Mono.Cecil/FieldReference.cs
@@ -71,13 +71,18 @@ namespace Mono.Cecil {
 			this.DeclaringType = declaringType;
 		}
 
-		public virtual FieldDefinition Resolve ()
+		protected override IMemberDefinition ResolveImpl()
 		{
 			var module = this.Module;
 			if (module == null)
-				throw new NotSupportedException ();
+				throw new NotSupportedException();
 
-			return module.Resolve (this);
+			return module.Resolve(this);
+		}
+
+		public new FieldDefinition Resolve()
+		{
+			return (FieldDefinition)base.Resolve();
 		}
 	}
 }

--- a/Mono.Cecil/FunctionPointerType.cs
+++ b/Mono.Cecil/FunctionPointerType.cs
@@ -116,7 +116,7 @@ namespace Mono.Cecil {
 			this.etype = MD.ElementType.FnPtr;
 		}
 
-		public override TypeDefinition Resolve ()
+		protected override IMemberDefinition ResolveImpl ()
 		{
 			return null;
 		}

--- a/Mono.Cecil/GenericParameter.cs
+++ b/Mono.Cecil/GenericParameter.cs
@@ -231,7 +231,7 @@ namespace Mono.Cecil {
 			throw new ArgumentOutOfRangeException ();
 		}
 
-		public override TypeDefinition Resolve ()
+		protected override IMemberDefinition ResolveImpl ()
 		{
 			return null;
 		}

--- a/Mono.Cecil/MemberReference.cs
+++ b/Mono.Cecil/MemberReference.cs
@@ -44,6 +44,13 @@ namespace Mono.Cecil {
 			get;
 		}
 
+		protected abstract IMemberDefinition ResolveImpl();
+
+		public IMemberDefinition Resolve()
+		{
+			return ResolveImpl();
+		}
+
 		public virtual TypeReference DeclaringType {
 			get { return declaring_type; }
 			set { declaring_type = value; }

--- a/Mono.Cecil/MethodDefinition.cs
+++ b/Mono.Cecil/MethodDefinition.cs
@@ -448,7 +448,7 @@ namespace Mono.Cecil {
 			this.token = new MetadataToken (TokenType.Method);
 		}
 
-		public override MethodDefinition Resolve ()
+		protected override IMemberDefinition ResolveImpl ()
 		{
 			return this;
 		}

--- a/Mono.Cecil/MethodReference.cs
+++ b/Mono.Cecil/MethodReference.cs
@@ -181,13 +181,18 @@ namespace Mono.Cecil {
 			return this;
 		}
 
-		public virtual MethodDefinition Resolve ()
+		protected override IMemberDefinition ResolveImpl()
 		{
 			var module = this.Module;
 			if (module == null)
 				throw new NotSupportedException ();
 
 			return module.Resolve (this);
+		}
+
+		public new MethodDefinition Resolve()
+		{
+			return (MethodDefinition)base.Resolve();
 		}
 	}
 

--- a/Mono.Cecil/PropertyDefinition.cs
+++ b/Mono.Cecil/PropertyDefinition.cs
@@ -254,7 +254,7 @@ namespace Mono.Cecil {
 			}
 		}
 
-		public override PropertyDefinition Resolve ()
+		protected override IMemberDefinition ResolveImpl ()
 		{
 			return this;
 		}

--- a/Mono.Cecil/PropertyReference.cs
+++ b/Mono.Cecil/PropertyReference.cs
@@ -54,6 +54,9 @@ namespace Mono.Cecil {
 			property_type = propertyType;
 		}
 
-		public abstract PropertyDefinition Resolve ();
+		public new PropertyDefinition Resolve()
+		{
+			return (PropertyDefinition)base.Resolve();
+		}
 	}
 }

--- a/Mono.Cecil/TypeDefinition.cs
+++ b/Mono.Cecil/TypeDefinition.cs
@@ -478,7 +478,7 @@ namespace Mono.Cecil {
 			this.BaseType = baseType;
 		}
 
-		public override TypeDefinition Resolve ()
+		protected override IMemberDefinition ResolveImpl ()
 		{
 			return this;
 		}

--- a/Mono.Cecil/TypeReference.cs
+++ b/Mono.Cecil/TypeReference.cs
@@ -264,13 +264,18 @@ namespace Mono.Cecil {
 			return this;
 		}
 
-		public virtual TypeDefinition Resolve ()
+		protected override IMemberDefinition ResolveImpl()
 		{
 			var module = this.Module;
 			if (module == null)
 				throw new NotSupportedException ();
 
 			return module.Resolve (this);
+		}
+
+		public new TypeDefinition Resolve()
+		{
+			return (TypeDefinition)base.Resolve();
 		}
 	}
 


### PR DESCRIPTION
Add a pseudo-covariant version of Resolve() to MemberReference to create a more complete common interface on MemberReference. The Resolve() in MemberReference returns a IMemberDefinition and is implemented by ResolveImpl. Each subclass can override ResolveImpl to change the behavior. In addition, each subclass implements a new method which returns the specific *Definition type and hides the Resolve() method in MemberReference. If you call Resolve() as a {Event,Field,Method,Property,Type}Reference, you get the appropriate type, but if you call it as a MemberReference, you get a IMemberDefinition.