### PR TITLE
Fix reading custom metadata so it doesn't blow up in Roslyn

### DIFF
--- a/symbols/pdb/Microsoft.Cci.Pdb/PdbFunction.cs
+++ b/symbols/pdb/Microsoft.Cci.Pdb/PdbFunction.cs
@@ -342,21 +342,20 @@ namespace Microsoft.Cci.Pdb {
       int savedPosition = bits.Position;
       byte version;
       bits.ReadUInt8(out version);
-      if (version != 4) {
-        throw new PdbDebugException("Unknown custom metadata item version: {0}", version);
-      }
       byte kind;
       bits.ReadUInt8(out kind);
       bits.Align(4);
       uint numberOfBytesInItem;
       bits.ReadUInt32(out numberOfBytesInItem);
-      switch (kind) {
-        case 0: this.ReadUsingInfo(bits); break;
-        case 1: this.ReadForwardInfo(bits); break;
-        case 2: break; // this.ReadForwardedToModuleInfo(bits); break;
-        case 3: this.ReadIteratorLocals(bits); break;
-        case 4: this.ReadForwardIterator(bits); break;
-        // TODO: handle unknown custom metadata, 5 & 6 are new with roslyn, see https://roslyn.codeplex.com/workitem/54
+      if (version == 4) {
+        switch (kind) {
+          case 0: this.ReadUsingInfo(bits); break;
+          case 1: this.ReadForwardInfo(bits); break;
+          case 2: break; // this.ReadForwardedToModuleInfo(bits); break;
+          case 3: this.ReadIteratorLocals(bits); break;
+          case 4: this.ReadForwardIterator(bits); break;
+          // TODO: handle unknown custom metadata, 5 & 6 are new with roslyn, see https://roslyn.codeplex.com/workitem/54
+        }
       }
       bits.Position = savedPosition+(int)numberOfBytesInItem;
     }


### PR DESCRIPTION
Cecil blows up in VS 2015 because Roslyn :P