### PR TITLE
fix importing owner-less Var/MVar types

### DIFF
--- a/Mono.Cecil/Import.cs
+++ b/Mono.Cecil/Import.cs
@@ -587,10 +587,14 @@ namespace Mono.Cecil {
 				return imported_instance;
 			case ElementType.Var:
 				var var_parameter = (GenericParameter) type;
-				return context.TypeParameter (type.DeclaringType.FullName, var_parameter.Position);
+				return type.DeclaringType != null
+					? context.TypeParameter(type.DeclaringType.FullName, var_parameter.Position)
+					: type;
 			case ElementType.MVar:
 				var mvar_parameter = (GenericParameter) type;
-				return context.MethodParameter (mvar_parameter.DeclaringMethod.Name, mvar_parameter.Position);
+				return mvar_parameter.DeclaringMethod != null
+					? context.MethodParameter(mvar_parameter.DeclaringMethod.Name, mvar_parameter.Position)
+					: type;
 			}
 
 			throw new NotSupportedException (type.etype.ToString ());

--- a/Test/Mono.Cecil.Tests/ImportCecilTests.cs
+++ b/Test/Mono.Cecil.Tests/ImportCecilTests.cs
@@ -221,6 +221,22 @@ namespace Mono.Cecil.Tests {
 			Assert.AreEqual ("T Mono.Cecil.Tests.ImportCecilTests/Generic`1::Method(T)", method.FullName);
 		}
 
+		[TestCase (GenericParameterType.Type)]
+		[TestCase (GenericParameterType.Method)]
+		public void ImportOwnerlessGenericParameter (GenericParameterType genericParameterType)
+		{
+			var module = ModuleDefinition.CreateModule ("foo", ModuleKind.Dll);
+			var openEnumerable = module.Import (typeof (IEnumerable<>));
+			var instanceEnumerable = new GenericInstanceType (openEnumerable);
+			var T = new GenericParameter (0, genericParameterType, module);
+			instanceEnumerable.GenericArguments.Add (T);
+
+			var module2 = ModuleDefinition.CreateModule ("bar", ModuleKind.Dll);
+			var imported = module2.Import (instanceEnumerable);
+
+			Assert.AreEqual (module2, imported.Module);
+		}
+
 		public class ContextGeneric1Method2<G1>
 		{
 			public G1 GenericMethod<R1, S1> (R1 r, S1 s)


### PR DESCRIPTION
Fix the crash when `new GenericParameter(position, type, module)`, which creates an ownerless generic parameter, is then `module.Import()`'ed (or any type reference using referencing it internally).