### PR TITLE
Allow upstream consumers to override build settings.

### DIFF
--- a/Mono.Cecil.csproj
+++ b/Mono.Cecil.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="Mono.Cecil.settings" />
   <PropertyGroup>
     <ProjectGuid>{D68133BD-1E63-496E-9EDE-4FBDBF77B486}</ProjectGuid>
     <RootNamespace>Mono.Cecil</RootNamespace>
@@ -139,5 +138,6 @@
     <Compile Include="Mono\Empty.cs" />
     <Compile Include="Mono\Funcs.cs" />
   </ItemGroup>
+  <Import Project="Mono.Cecil.settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Mono.Cecil.settings
+++ b/Mono.Cecil.settings
@@ -16,14 +16,14 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE;</DefineConstants>
+    <DefineConstants>$(DefineConstants);DEBUG;TRACE;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" $(Configuration.EndsWith('Release')) ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>false</RunCodeAnalysis>
@@ -86,4 +86,39 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'winphone_Release' ">
   </PropertyGroup>
+
+  <!-- This optional import allows products that distribute Cecil to tweak settings that will affect its 
+       build, without having to fork the project unnecessarily. The Mono.Cecil.overrides file is a plain 
+       MSBuild file with additional properties, and can exist anywhere upwards from the current Cecil repo 
+       clone path, making it very flexible even if the project is submoduled. 
+  -->
+  <PropertyGroup>
+    <CecilOverrides Condition="'$(CecilOverrides)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Mono.Cecil.overrides))\Mono.Cecil.overrides</CecilOverrides>
+  </PropertyGroup>  
+  <Import Project="$(CecilOverrides)" Condition="Exists($(CecilOverrides))" />
+  
+  <!-- This is an example of a custom override file -->
+  <!--
+	<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	  <PropertyGroup>
+		<AssemblyName>$(AssemblyName.Replace('Mono', 'MyCompany'))</AssemblyName>
+		<AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)MyCompany.snk</AssemblyOriginatorKeyFile>
+	  </PropertyGroup>
+		<ItemGroup>
+			<Compile Include="$(MSBuildThisFileDirectory)MyCompany.AssemblyInfo.cs" />
+		</ItemGroup>
+	</Project>
+	
+	The additional AssemblyInfo.cs added to the Compile group provides the InternalsVisibleTo so that 
+	the Mdb/Pdb projects can compile successfully:
+	
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: InternalsVisibleTo ("MyCompany.Cecil.Pdb, PublicKey=....")]
+[assembly: InternalsVisibleTo ("MyCompany.Cecil.Mdb, PublicKey=...")]
+[assembly: InternalsVisibleTo ("MyCompany.Cecil.Rocks, PublicKey=...")]
+[assembly: InternalsVisibleTo ("MyCompany.Cecil.Tests, PublicKey=...")]	
+  -->
 </Project>

--- a/Test/Mono.Cecil.Tests.csproj
+++ b/Test/Mono.Cecil.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\Mono.Cecil.Tests.settings" />
   <PropertyGroup>
     <ProjectGuid>{A47B1F49-A81A-43E8-BE6B-DD28AF2C4055}</ProjectGuid>
     <RootNamespace>Mono.Cecil.Tests</RootNamespace>
@@ -85,5 +84,6 @@
     <Content Include="Resources\assemblies\text_file.txt" />
     <Content Include="Resources\assemblies\varargs.exe" />
   </ItemGroup>
+  <Import Project="..\Mono.Cecil.Tests.settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/rocks/Mono.Cecil.Rocks.csproj
+++ b/rocks/Mono.Cecil.Rocks.csproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\Mono.Cecil.settings" />
   <PropertyGroup>
     <ProjectGuid>{FBC6DD59-D09D-499C-B03C-99C1C78FF2AC}</ProjectGuid>
     <RootNamespace>Mono.Cecil.Rocks</RootNamespace>
@@ -25,5 +24,6 @@
       <Name>Mono.Cecil</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="..\Mono.Cecil.settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/rocks/Test/Mono.Cecil.Rocks.Tests.csproj
+++ b/rocks/Test/Mono.Cecil.Rocks.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Mono.Cecil.Tests.settings" />
   <PropertyGroup>
     <ProjectGuid>{C6CFD7E1-B855-44DC-B4CE-9CD72984AF52}</ProjectGuid>
     <RootNamespace>Mono.Cecil.Rocks.Tests</RootNamespace>
@@ -32,5 +31,6 @@
     <Content Include="Resources\assemblies\decsec-att.dll" />
     <Content Include="Resources\assemblies\decsec-xml.dll" />
   </ItemGroup>
+  <Import Project="..\..\Mono.Cecil.Tests.settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/symbols/mdb/Mono.Cecil.Mdb.csproj
+++ b/symbols/mdb/Mono.Cecil.Mdb.csproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Mono.Cecil.settings" />
   <PropertyGroup>
     <ProjectGuid>{8559DD7F-A16F-46D0-A05A-9139FAEBA8FD}</ProjectGuid>
     <RootNamespace>Mono.Cecil.Mdb</RootNamespace>
@@ -30,5 +29,6 @@
     <Compile Include="Mono.CompilerServices.SymbolWriter\SourceMethodBuilder.cs" />
     <Compile Include="Mono.CompilerServices.SymbolWriter\SymbolWriterImpl.cs" />
   </ItemGroup>
+  <Import Project="..\..\Mono.Cecil.settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/symbols/mdb/Test/Mono.Cecil.Mdb.Tests.csproj
+++ b/symbols/mdb/Test/Mono.Cecil.Mdb.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\Mono.Cecil.Tests.settings" />
   <PropertyGroup>
     <ProjectGuid>{AC71DF9C-99FA-4A63-990A-66C8010355A6}</ProjectGuid>
     <RootNamespace>Mono.Cecil.Mdb.Tests</RootNamespace>
@@ -27,5 +26,6 @@
     <Content Include="Resources\assemblies\hello.exe" />
     <Content Include="Resources\assemblies\hello.exe.mdb" />
   </ItemGroup>
+  <Import Project="..\..\..\Mono.Cecil.Tests.settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/symbols/pdb/Mono.Cecil.Pdb.csproj
+++ b/symbols/pdb/Mono.Cecil.Pdb.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Mono.Cecil.settings" />
   <PropertyGroup>
     <ProjectGuid>{63E6915C-7EA4-4D76-AB28-0D7191EEA626}</ProjectGuid>
     <RootNamespace>Mono.Cecil.Pdb</RootNamespace>
@@ -50,5 +49,6 @@
     <Compile Include="Mono.Cecil.Pdb\SymDocumentWriter.cs" />
     <Compile Include="Mono.Cecil.Pdb\SymWriter.cs" />
   </ItemGroup>
+  <Import Project="..\..\Mono.Cecil.settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/symbols/pdb/Test/Mono.Cecil.Pdb.Tests.csproj
+++ b/symbols/pdb/Test/Mono.Cecil.Pdb.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\Mono.Cecil.Tests.settings" />
   <PropertyGroup>
     <ProjectGuid>{29300103-CB76-4A1D-B6FD-FFD91C1EC8AA}</ProjectGuid>
     <RootNamespace>Mono.Cecil.Pdb.Tests</RootNamespace>
@@ -32,5 +31,6 @@
     <Content Include="Resources\assemblies\VBConsApp.exe" />
     <Content Include="Resources\assemblies\VBConsApp.pdb" />
   </ItemGroup>
+  <Import Project="..\..\..\Mono.Cecil.Tests.settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Projects consuming and distributing Cecil in environments they
don't control (i.e. an addin inside VS or XS) risk having the
environment load an incompatible version of Cecil from another
addin or location (depending on the process/domain configuration
and the probing paths set up for the host).

To shield from this issue, XS has forked Cecil, changed its
assembly name and signing key, and now it has to maintain that
fork in sync with upstream. Others with similar requirements
(in particular, the Xamarin Visual Studio extension team now)
will need to do the same, with the added maintainability burden.

This commit provides a conditional import that allows products
that distribute Cecil to tweak settings that will affect its
build, without having to fork the project unnecessarily. The
Mono.Cecil.overrides file is a plain MSBuild file with additional
properties that can exist anywhere upwards from the current Cecil
repo clone path, making it very flexible even if the project
is submoduled.

It's imported before the C# targets so that changes to the
assembly name, signing key, etc. are properly overwritten before
the C# targets process them.

Fixes #216