### PR TITLE
Added travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: csharp
+solution: Mono.Cecil.sln
+install:
+  - nuget restore Mono.Cecil.sln
+  - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
+script:
+  - xbuild /p:Configuration=net_4_0_Debug Mono.Cecil.sln
+  - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe Mono.Cecil.nunit

--- a/Mono.Cecil.nunit
+++ b/Mono.Cecil.nunit
@@ -1,9 +1,9 @@
 <NUnitProject>
   <Settings activeconfig="Default" domainUsage="Multiple" />
   <Config name="Default" binpathtype="Auto" runtimeFramework="v4.0.21006">
-    <assembly path="Test\bin\net_4_0_Debug\Mono.Cecil.Tests.dll" />
-    <assembly path="rocks\Test\bin\net_4_0_Debug\Mono.Cecil.Rocks.Tests.dll" />
-    <assembly path="symbols\mdb\Test\bin\net_4_0_Debug\Mono.Cecil.Mdb.Tests.dll" />
-    <assembly path="symbols\pdb\Test\bin\net_4_0_Debug\Mono.Cecil.Pdb.Tests.dll" />
+    <assembly path="Test/bin/net_4_0_Debug/Mono.Cecil.Tests.dll" />
+    <assembly path="rocks/Test/bin/net_4_0_Debug/Mono.Cecil.Rocks.Tests.dll" />
+    <assembly path="symbols/mdb/Test/bin/net_4_0_Debug/Mono.Cecil.Mdb.Tests.dll" />
+    <assembly path="symbols/pdb/Test/bin/net_4_0_Debug/Mono.Cecil.Pdb.Tests.dll" />
   </Config>
 </NUnitProject>


### PR DESCRIPTION
In case you're interested in having mono CI for Cecil, here's the travis conf you can use.
Mono.Cecil.nunit change is compatible with Windows (the old version wasn't working on linux).

Note that there are ~25 UT failures on mono/linux, so enabling travis on Cecil will bring red'ish stickers (rather than green-ish) on PRs.

I also suggest the appveyor config gets commited to the repo in the same way, it's more sane when working with branches and provides a changelog for build configs. You can go to appveyor settings, select "export YAML".