### PR TITLE
Cache type refs during import

### DIFF
--- a/Mono.Cecil/Import.cs
+++ b/Mono.Cecil/Import.cs
@@ -482,6 +482,7 @@ namespace Mono.Cecil {
 
 	public class MetadataImporter : IMetadataImporter {
 
+		readonly Dictionary<TypeRefKey, TypeReference> cache = new Dictionary<TypeRefKey, TypeReference> ();
 		readonly ModuleDefinition module;
 
 		public MetadataImporter (ModuleDefinition module)
@@ -491,12 +492,47 @@ namespace Mono.Cecil {
 			this.module = module;
 		}
 
+		struct TypeRefKey : IEquatable<TypeRefKey>
+		{
+			string fullname;
+			string assembly;
+
+			public static TypeRefKey From (TypeReference r)
+			{
+				return new TypeRefKey { fullname = r.FullName, assembly = r.Module.FullyQualifiedName };
+			}
+
+			public override int GetHashCode ()
+			{
+				return fullname.GetHashCode () + assembly.GetHashCode ();
+			}
+
+			public bool Equals (TypeRefKey other)
+			{
+				return other.fullname == fullname && other.assembly == assembly;
+			}
+		}
+
 		TypeReference ImportType (TypeReference type, ImportGenericContext context)
 		{
 			if (type.IsTypeSpecification ())
 				return ImportTypeSpecification (type, context);
 
-			var reference = new TypeReference (
+			TypeReference reference;
+			var key = TypeRefKey.From (type);
+			if (cache.TryGetValue (key, out reference))
+			{
+				// Cecil only fills TypeRef GenericParameters if used ( bug ?)
+				// Now that we cache them, we need to make sure the cached version has all of the needed ones
+				if (type.HasGenericParameters && reference.GenericParameters.Count != type.GenericParameters.Count)
+				{
+					for (int i = reference.GenericParameters.Count - 1; i < type.GenericParameters.Count; i++)
+						reference.GenericParameters.Add (new GenericParameter (reference));
+				}
+				return reference;
+			}
+
+			reference = new TypeReference (
 				type.Namespace,
 				type.Name,
 				module,
@@ -510,6 +546,8 @@ namespace Mono.Cecil {
 
 			if (type.HasGenericParameters)
 				ImportGenericParameters (reference, type);
+
+			cache.Add (key, reference);
 
 			return reference;
 		}


### PR DESCRIPTION
- importing many types/methods would result in millions of duplicate
 TypeRef objects, this basic caching saves lots of memory in that use case.
- one issue with it has to do with Cecil not filling up GenericParameters
 for all types (hence the workaround). Was seen during Dapper or Bcl UTs.

I guess this change can be debated, but as it bring a large perf impact for ILRepack (~20%), I kind'o need it :smile: 
Other ways to tackle it would be:
- to add an option for the metadataimporter to cache (or not)
- make the metadataimporter public & overrideable, so that one (ILRepack) could add a caching layer on top of it

If those sound more appropriate for Cecil, I can modify this PR accordingly (though IMO, all import use cases would benefit from this cache).

MethodRef could/should be cached similarly, but the impact is lesser than TypeRefs.