### PR TITLE
Compact MetadataSystem dicts after assembly load

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -128,6 +128,7 @@ namespace Mono.Cecil {
 			this.module.Read (this.module, (module, reader) => {
 				ReadModuleManifest (reader);
 				ReadModule (module);
+				module.MetadataSystem.Clear ();
 				return module;
 			});
 		}

--- a/Mono.Cecil/MetadataSystem.cs
+++ b/Mono.Cecil/MetadataSystem.cs
@@ -127,23 +127,23 @@ namespace Mono.Cecil {
 
 		public void Clear ()
 		{
-			if (NestedTypes != null) NestedTypes.Clear ();
-			if (ReverseNestedTypes != null) ReverseNestedTypes.Clear ();
-			if (Interfaces != null) Interfaces.Clear ();
-			if (ClassLayouts != null) ClassLayouts.Clear ();
-			if (FieldLayouts != null) FieldLayouts.Clear ();
-			if (FieldRVAs != null) FieldRVAs.Clear ();
-			if (FieldMarshals != null) FieldMarshals.Clear ();
-			if (Constants != null) Constants.Clear ();
-			if (Overrides != null) Overrides.Clear ();
-			if (CustomAttributes != null) CustomAttributes.Clear ();
-			if (SecurityDeclarations != null) SecurityDeclarations.Clear ();
-			if (Events != null) Events.Clear ();
-			if (Properties != null) Properties.Clear ();
-			if (Semantics != null) Semantics.Clear ();
-			if (PInvokes != null) PInvokes.Clear ();
-			if (GenericParameters != null) GenericParameters.Clear ();
-			if (GenericConstraints != null) GenericConstraints.Clear ();
+			if (NestedTypes != null) NestedTypes = new Dictionary<uint, uint[]> ();
+			if (ReverseNestedTypes != null) ReverseNestedTypes = new Dictionary<uint, uint> ();
+			if (Interfaces != null) Interfaces = new Dictionary<uint, MetadataToken[]> ();
+			if (ClassLayouts != null) ClassLayouts = new Dictionary<uint, Row<ushort, uint>> ();
+			if (FieldLayouts != null) FieldLayouts = new Dictionary<uint, uint> ();
+			if (FieldRVAs != null) FieldRVAs = new Dictionary<uint, uint> ();
+			if (FieldMarshals != null) FieldMarshals = new Dictionary<MetadataToken, uint> ();
+			if (Constants != null) Constants = new Dictionary<MetadataToken, Row<ElementType, uint>> ();
+			if (Overrides != null) Overrides = new Dictionary<uint, MetadataToken[]> ();
+			if (CustomAttributes != null) CustomAttributes = new Dictionary<MetadataToken, Range[]> ();
+			if (SecurityDeclarations != null) SecurityDeclarations = new Dictionary<MetadataToken, Range[]> ();
+			if (Events != null) Events = new Dictionary<uint, Range> ();
+			if (Properties != null) Properties = new Dictionary<uint, Range> ();
+			if (Semantics != null) Semantics = new Dictionary<uint, Row<MethodSemanticsAttributes, MetadataToken>> ();
+			if (PInvokes != null) PInvokes = new Dictionary<uint, Row<PInvokeAttributes, uint, uint>> ();
+			if (GenericParameters != null) GenericParameters = new Dictionary<MetadataToken, Range[]> ();
+			if (GenericConstraints != null) GenericConstraints = new Dictionary<uint, MetadataToken[]> ();
 		}
 
 		public TypeDefinition GetTypeDefinition (uint rid)


### PR DESCRIPTION
- not 100% sure about this one, but my assumption was that:
"when using the ImmediateModuleReader, the metadata system
 caches should all be empty (all resolved) after load."
(but I'm not sure that's correct)

- If that holds true, then this change works, and makes sure that
 the (fairly large) dicts gets compacted (by GC'ing them).