### PR TITLE
Allow setting of TypeSpecification's namespace and name

### DIFF
--- a/Mono.Cecil/TypeSpecification.cs
+++ b/Mono.Cecil/TypeSpecification.cs
@@ -24,12 +24,12 @@ namespace Mono.Cecil {
 
 		public override string Name {
 			get { return element_type.Name; }
-			set { throw new InvalidOperationException (); }
+			set { element_type.Name = value; }
 		}
 
 		public override string Namespace {
 			get { return element_type.Namespace; }
-			set { throw new InvalidOperationException (); }
+			set { element_type.Namespace = value; }
 		}
 
 		public override IMetadataScope Scope {


### PR DESCRIPTION
It's not an invalid operation. In fact it's working fine and is required to fix my issue.