### PR TITLE
Emitting byte constants

### DIFF
--- a/Mono.Cecil.Cil/CodeWriter.cs
+++ b/Mono.Cecil.Cil/CodeWriter.cs
@@ -209,7 +209,7 @@ namespace Mono.Cecil.Cil {
 				WriteMetadataToken (GetStandAloneSignature ((CallSite) operand));
 				break;
 			case OperandType.ShortInlineI:
-				if (opcode == OpCodes.Ldc_I4_S)
+				if (operand.GetType() == typeof(sbyte))
 					WriteSByte ((sbyte) operand);
 				else
 					WriteByte ((byte) operand);

--- a/Mono.Cecil.Cil/Instruction.cs
+++ b/Mono.Cecil.Cil/Instruction.cs
@@ -209,7 +209,7 @@ namespace Mono.Cecil.Cil {
 
 		public static Instruction Create (OpCode opcode, sbyte value)
 		{
-			if (opcode.OperandType != OperandType.ShortInlineI &&
+			if (opcode.OperandType != OperandType.ShortInlineI ||
 				opcode != OpCodes.Ldc_I4_S)
 				throw new ArgumentException ("opcode");
 
@@ -219,7 +219,7 @@ namespace Mono.Cecil.Cil {
 		public static Instruction Create (OpCode opcode, byte value)
 		{
 			if (opcode.OperandType != OperandType.ShortInlineI ||
-				opcode == OpCodes.Ldc_I4_S)
+				opcode != OpCodes.Ldc_I4_S)
 				throw new ArgumentException ("opcode");
 
 			return new Instruction (opcode, value);


### PR DESCRIPTION
Ran into this recently - Cecil was choking on LDC_I4_S for byte constant values, and closer inspection revealed what seemed like nonsensical behaviour in the opcode-checking and operand-writing departments. Is this right(?)