### PR TITLE
Windows Runtime projections

### DIFF
--- a/Mono.Cecil.csproj
+++ b/Mono.Cecil.csproj
@@ -55,8 +55,10 @@
     <Compile Include="Mono.Cecil\AssemblyWriter.cs" />
     <Compile Include="Mono.Cecil\BaseAssemblyResolver.cs" />
     <Compile Include="Mono.Cecil\CallSite.cs" />
+    <Compile Include="Mono.Cecil\Treatments.cs" />
     <Compile Include="Mono.Cecil\TypeParser.cs" />
     <Compile Include="Mono.Cecil\Import.cs" />
+    <Compile Include="Mono.Cecil\WindowsRuntimeProjections.cs" />
     <Compile Include="Mono.Collections.Generic\Collection.cs" />
     <Compile Include="Mono.Cecil\ExportedType.cs" />
     <Compile Include="Mono.Cecil\SecurityDeclaration.cs" />

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -78,10 +78,11 @@ namespace Mono.Cecil {
 #endif
 #endif
 
+			GetMetadataKind(module, parameters);
+
 			reader.ReadModule ();
 
 			ReadSymbols (module, parameters);
-			GetMetadataKind (module, parameters);
 
 			return module;
 		}

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -898,7 +898,7 @@ namespace Mono.Cecil {
 				type.DeclaringType = GetNestedTypeDeclaringType (type);
 
 			if (module.MetadataKind != MetadataKind.Ecma335)
-				module.Projections.Project (type);
+				WindowsRuntimeProjections.Project (type);
 
 			return type;
 		}
@@ -1084,7 +1084,7 @@ namespace Mono.Cecil {
 			MetadataSystem.TryProcessPrimitiveTypeReference (type);
 
 			if (type.Module.MetadataKind != MetadataKind.Ecma335)
-				type.Module.Projections.Project (type);
+				WindowsRuntimeProjections.Project (type);
 
 			return type;
 		}
@@ -1235,7 +1235,7 @@ namespace Mono.Cecil {
 			fields.Add (field);
 
 			if (module.MetadataKind != MetadataKind.Ecma335)
-				field.Module.Projections.Project (field);
+				WindowsRuntimeProjections.Project (field);
 		}
 
 		void InitializeFields ()
@@ -1758,7 +1758,7 @@ namespace Mono.Cecil {
 			}
 
 			if (module.MetadataKind != MetadataKind.Ecma335)
-				module.Projections.Project (method);
+				WindowsRuntimeProjections.Project (method);
 		}
 
 		void ReadParameters (MethodDefinition method, Range param_range)
@@ -2271,7 +2271,7 @@ namespace Mono.Cecil {
 			member.token = new MetadataToken (TokenType.MemberRef, rid);
 
 			if (module.MetadataKind != MetadataKind.Ecma335)
-				module.Projections.Project (member);
+				WindowsRuntimeProjections.Project (member);
 
 			return member;
 		}
@@ -2445,7 +2445,7 @@ namespace Mono.Cecil {
 
 			if (module.MetadataKind != MetadataKind.Ecma335)
 				foreach (var custom_attribute in custom_attributes)
-					module.Projections.Project (owner, custom_attribute);
+					WindowsRuntimeProjections.Project (owner, custom_attribute);
 
 			return custom_attributes;
 		}
@@ -2455,7 +2455,7 @@ namespace Mono.Cecil {
 			if (!MoveTo (Table.CustomAttribute, range.Start))
 				return;
 
-			for (RVA i = 0; i < range.Length; i++) {
+			for (var i = 0; i < range.Length; i++) {
 				ReadMetadataToken (CodedIndex.HasCustomAttribute);
 
 				var constructor = (MethodReference) LookupToken (
@@ -2463,7 +2463,7 @@ namespace Mono.Cecil {
 
 				var signature = ReadBlobIndex ();
 
-				custom_attributes.Add (new CustomAttribute (new MetadataToken (TokenType.CustomAttribute, range.Start + i), signature, constructor));
+				custom_attributes.Add (new CustomAttribute (signature, constructor));
 			}
 		}
 

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1164,9 +1164,7 @@ namespace Mono.Cecil {
 
 		MetadataToken GetTypeRefToken (TypeReference type)
 		{
-			var treatment = type.Treatment;
-			if (treatment != TypeReferenceTreatment.None)
-				type.Module.Projections.RemoveTreatment (type);
+			var treatment = WindowsRuntimeProjections.RemoveProjection (type);
 
 			var row = CreateTypeRefRow (type);
 
@@ -1174,8 +1172,7 @@ namespace Mono.Cecil {
 			if (!type_ref_map.TryGetValue (row, out token))
 				token = AddTypeReference (type, row);
 
-			if (treatment != TypeReferenceTreatment.None)
-				type.Module.Projections.ApplyTreatment (type, treatment);
+			WindowsRuntimeProjections.ApplyProjection (type, treatment);
 
 			return token;
 		}
@@ -1232,6 +1229,8 @@ namespace Mono.Cecil {
 
 		void AddType (TypeDefinition type)
 		{
+			var treatment = WindowsRuntimeProjections.RemoveProjection (type);
+
 			type_def_table.AddRow (new TypeDefRow (
 				type.Attributes,
 				GetStringIndex (type.Name),
@@ -1269,6 +1268,8 @@ namespace Mono.Cecil {
 
 			if (type.HasNestedTypes)
 				AddNestedTypes (type);
+
+			WindowsRuntimeProjections.ApplyProjection (type, treatment);
 		}
 
 		void AddGenericParameters (IGenericParameterProvider owner)
@@ -1378,9 +1379,7 @@ namespace Mono.Cecil {
 
 		void AddField (FieldDefinition field)
 		{
-			var treatment = field.Treatment;
-			if (treatment != FieldDefinitionTreatment.None)
-				field.Module.Projections.RemoveTreatment (field);
+			var treatment = WindowsRuntimeProjections.RemoveProjection (field);
 
 			field_table.AddRow (new FieldRow (
 				field.Attributes,
@@ -1402,8 +1401,7 @@ namespace Mono.Cecil {
 			if (field.HasMarshalInfo)
 				AddMarshalInfo (field);
 
-			if (treatment != FieldDefinitionTreatment.None)
-				field.Module.Projections.ApplyTreatment (field, treatment);
+			WindowsRuntimeProjections.ApplyProjection (field, treatment);
 		}
 
 		void AddFieldRVA (FieldDefinition field)
@@ -1430,9 +1428,7 @@ namespace Mono.Cecil {
 
 		void AddMethod (MethodDefinition method)
 		{
-			var treatment = method.Treatment;
-			if (treatment != MethodDefinitionTreatment.None)
-				method.Module.Projections.RemoveTreatment (method);
+			var treatment = WindowsRuntimeProjections.RemoveProjection (method);
 
 			method_table.AddRow (new MethodRow (
 				method.HasBody ? code.WriteMethodBody (method) : 0,
@@ -1459,8 +1455,7 @@ namespace Mono.Cecil {
 			if (method.HasOverrides)
 				AddOverrides (method);
 
-			if (treatment != MethodDefinitionTreatment.None)
-				method.Module.Projections.ApplyTreatment (method, treatment);
+			WindowsRuntimeProjections.ApplyProjection (method, treatment);
 		}
 
 		void AddParameters (MethodDefinition method)
@@ -1743,19 +1738,14 @@ namespace Mono.Cecil {
 			for (int i = 0; i < custom_attributes.Count; i++) {
 				var attribute = custom_attributes [i];
 
-				var treatment = attribute.treatment;
-				if (treatment != CustomAttributeValueTreatment.None)
-					attribute.Module.Projections.RemoveTreatment (attribute);
+				var treatment = WindowsRuntimeProjections.RemoveProjection (attribute);
 
-				var rid = custom_attribute_table.AddRow (new CustomAttributeRow (
+				custom_attribute_table.AddRow (new CustomAttributeRow (
 					MakeCodedRID (owner, CodedIndex.HasCustomAttribute),
 					MakeCodedRID (LookupToken (attribute.Constructor), CodedIndex.CustomAttributeType),
 					GetBlobIndex (GetCustomAttributeSignature (attribute))));
 
-				attribute.MetadataToken = new MetadataToken (TokenType.CustomAttribute, rid);
-
-				if (treatment != CustomAttributeValueTreatment.None)
-					attribute.Module.Projections.ApplyTreatment (attribute, treatment);
+				WindowsRuntimeProjections.ApplyProjection (attribute, treatment);
 			}
 		}
 
@@ -1775,9 +1765,7 @@ namespace Mono.Cecil {
 
 		MetadataToken GetMemberRefToken (MemberReference member)
 		{
-			var treatment = member.Treatment;
-			if (treatment != MemberReferenceTreatment.None)
-				member.Module.Projections.RemoveTreatment (member);
+			var treatment = WindowsRuntimeProjections.RemoveProjection (member);
 
 			var row = CreateMemberRefRow (member);
 
@@ -1785,8 +1773,7 @@ namespace Mono.Cecil {
 			if (!member_ref_map.TryGetValue (row, out token))
 				token = AddMemberReference (member, row);
 
-			if (treatment != MemberReferenceTreatment.None)
-				member.Module.Projections.ApplyTreatment (member, treatment);
+			WindowsRuntimeProjections.ApplyProjection (member, treatment);
 
 			return token;
 		}

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1164,7 +1164,7 @@ namespace Mono.Cecil {
 
 		MetadataToken GetTypeRefToken (TypeReference type)
 		{
-			var treatment = WindowsRuntimeProjections.RemoveProjection (type);
+			var projection = WindowsRuntimeProjections.RemoveProjection (type);
 
 			var row = CreateTypeRefRow (type);
 
@@ -1172,7 +1172,7 @@ namespace Mono.Cecil {
 			if (!type_ref_map.TryGetValue (row, out token))
 				token = AddTypeReference (type, row);
 
-			WindowsRuntimeProjections.ApplyProjection (type, treatment);
+			WindowsRuntimeProjections.ApplyProjection (type, projection);
 
 			return token;
 		}
@@ -1379,7 +1379,7 @@ namespace Mono.Cecil {
 
 		void AddField (FieldDefinition field)
 		{
-			var treatment = WindowsRuntimeProjections.RemoveProjection (field);
+			var projection = WindowsRuntimeProjections.RemoveProjection (field);
 
 			field_table.AddRow (new FieldRow (
 				field.Attributes,
@@ -1401,7 +1401,7 @@ namespace Mono.Cecil {
 			if (field.HasMarshalInfo)
 				AddMarshalInfo (field);
 
-			WindowsRuntimeProjections.ApplyProjection (field, treatment);
+			WindowsRuntimeProjections.ApplyProjection (field, projection);
 		}
 
 		void AddFieldRVA (FieldDefinition field)
@@ -1428,7 +1428,7 @@ namespace Mono.Cecil {
 
 		void AddMethod (MethodDefinition method)
 		{
-			var treatment = WindowsRuntimeProjections.RemoveProjection (method);
+			var projection = WindowsRuntimeProjections.RemoveProjection (method);
 
 			method_table.AddRow (new MethodRow (
 				method.HasBody ? code.WriteMethodBody (method) : 0,
@@ -1455,7 +1455,7 @@ namespace Mono.Cecil {
 			if (method.HasOverrides)
 				AddOverrides (method);
 
-			WindowsRuntimeProjections.ApplyProjection (method, treatment);
+			WindowsRuntimeProjections.ApplyProjection (method, projection);
 		}
 
 		void AddParameters (MethodDefinition method)
@@ -1738,14 +1738,14 @@ namespace Mono.Cecil {
 			for (int i = 0; i < custom_attributes.Count; i++) {
 				var attribute = custom_attributes [i];
 
-				var treatment = WindowsRuntimeProjections.RemoveProjection (attribute);
+				var projection = WindowsRuntimeProjections.RemoveProjection (attribute);
 
 				custom_attribute_table.AddRow (new CustomAttributeRow (
 					MakeCodedRID (owner, CodedIndex.HasCustomAttribute),
 					MakeCodedRID (LookupToken (attribute.Constructor), CodedIndex.CustomAttributeType),
 					GetBlobIndex (GetCustomAttributeSignature (attribute))));
 
-				WindowsRuntimeProjections.ApplyProjection (attribute, treatment);
+				WindowsRuntimeProjections.ApplyProjection (attribute, projection);
 			}
 		}
 
@@ -1765,7 +1765,7 @@ namespace Mono.Cecil {
 
 		MetadataToken GetMemberRefToken (MemberReference member)
 		{
-			var treatment = WindowsRuntimeProjections.RemoveProjection (member);
+			var projection = WindowsRuntimeProjections.RemoveProjection (member);
 
 			var row = CreateMemberRefRow (member);
 
@@ -1773,7 +1773,7 @@ namespace Mono.Cecil {
 			if (!member_ref_map.TryGetValue (row, out token))
 				token = AddMemberReference (member, row);
 
-			WindowsRuntimeProjections.ApplyProjection (member, treatment);
+			WindowsRuntimeProjections.ApplyProjection (member, projection);
 
 			return token;
 		}

--- a/Mono.Cecil/CustomAttribute.cs
+++ b/Mono.Cecil/CustomAttribute.cs
@@ -68,6 +68,8 @@ namespace Mono.Cecil {
 
 	public sealed class CustomAttribute : ICustomAttribute {
 
+		internal MetadataToken token;
+		internal CustomAttributeValueTreatment treatment = CustomAttributeValueTreatment.None;
 		readonly internal uint signature;
 		internal bool resolved;
 		MethodReference constructor;
@@ -75,6 +77,11 @@ namespace Mono.Cecil {
 		internal Collection<CustomAttributeArgument> arguments;
 		internal Collection<CustomAttributeNamedArgument> fields;
 		internal Collection<CustomAttributeNamedArgument> properties;
+
+		public MetadataToken MetadataToken {
+			get { return token; }
+			set { token = value; }
+		}
 
 		public MethodReference Constructor {
 			get { return constructor; }
@@ -145,20 +152,28 @@ namespace Mono.Cecil {
 			get { return constructor.Module; }
 		}
 
-		internal CustomAttribute (uint signature, MethodReference constructor)
+		private CustomAttribute ()
 		{
+			this.token = new MetadataToken (TokenType.CustomAttribute, 0);
+		}
+
+		internal CustomAttribute (MetadataToken token, uint signature, MethodReference constructor)
+		{
+			this.token = token;
 			this.signature = signature;
 			this.constructor = constructor;
 			this.resolved = false;
 		}
 
 		public CustomAttribute (MethodReference constructor)
+			: this()
 		{
 			this.constructor = constructor;
 			this.resolved = true;
 		}
 
 		public CustomAttribute (MethodReference constructor, byte [] blob)
+			: this()
 		{
 			this.constructor = constructor;
 			this.resolved = false;

--- a/Mono.Cecil/CustomAttribute.cs
+++ b/Mono.Cecil/CustomAttribute.cs
@@ -68,8 +68,7 @@ namespace Mono.Cecil {
 
 	public sealed class CustomAttribute : ICustomAttribute {
 
-		internal MetadataToken token;
-		internal CustomAttributeValueTreatment treatment = CustomAttributeValueTreatment.None;
+		internal object projection;
 		readonly internal uint signature;
 		internal bool resolved;
 		MethodReference constructor;
@@ -77,11 +76,6 @@ namespace Mono.Cecil {
 		internal Collection<CustomAttributeArgument> arguments;
 		internal Collection<CustomAttributeNamedArgument> fields;
 		internal Collection<CustomAttributeNamedArgument> properties;
-
-		public MetadataToken MetadataToken {
-			get { return token; }
-			set { token = value; }
-		}
 
 		public MethodReference Constructor {
 			get { return constructor; }
@@ -152,28 +146,20 @@ namespace Mono.Cecil {
 			get { return constructor.Module; }
 		}
 
-		private CustomAttribute ()
+		internal CustomAttribute (uint signature, MethodReference constructor)
 		{
-			this.token = new MetadataToken (TokenType.CustomAttribute, 0);
-		}
-
-		internal CustomAttribute (MetadataToken token, uint signature, MethodReference constructor)
-		{
-			this.token = token;
 			this.signature = signature;
 			this.constructor = constructor;
 			this.resolved = false;
 		}
 
 		public CustomAttribute (MethodReference constructor)
-			: this()
 		{
 			this.constructor = constructor;
 			this.resolved = true;
 		}
 
 		public CustomAttribute (MethodReference constructor, byte [] blob)
-			: this()
 		{
 			this.constructor = constructor;
 			this.resolved = false;

--- a/Mono.Cecil/CustomAttribute.cs
+++ b/Mono.Cecil/CustomAttribute.cs
@@ -68,7 +68,7 @@ namespace Mono.Cecil {
 
 	public sealed class CustomAttribute : ICustomAttribute {
 
-		internal object projection;
+		internal CustomAttributeValueProjection projection;
 		readonly internal uint signature;
 		internal bool resolved;
 		MethodReference constructor;

--- a/Mono.Cecil/FieldDefinition.cs
+++ b/Mono.Cecil/FieldDefinition.cs
@@ -8,6 +8,7 @@
 // Licensed under the MIT/X11 license.
 //
 
+using System;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -37,6 +38,11 @@ namespace Mono.Cecil {
 			}
 
 			offset = Module.Read (this, (field, reader) => reader.ReadFieldLayout (field));
+		}
+
+		internal new FieldDefinitionTreatment Treatment {
+			get { return (FieldDefinitionTreatment) base.treatment; }
+			set { base.treatment = (uint) value; }
 		}
 
 		public bool HasLayoutInfo {
@@ -104,7 +110,11 @@ namespace Mono.Cecil {
 
 		public FieldAttributes Attributes {
 			get { return (FieldAttributes) attributes; }
-			set { attributes = (ushort) value; }
+			set {
+				if (Treatment != FieldDefinitionTreatment.None && (ushort) value != attributes)
+					throw new InvalidOperationException ("Projected field definition attributes can't be changed.");
+				attributes = (ushort) value;
+			}
 		}
 
 		public bool HasConstant {

--- a/Mono.Cecil/FieldDefinition.cs
+++ b/Mono.Cecil/FieldDefinition.cs
@@ -40,11 +40,6 @@ namespace Mono.Cecil {
 			offset = Module.Read (this, (field, reader) => reader.ReadFieldLayout (field));
 		}
 
-		internal new FieldDefinitionTreatment Treatment {
-			get { return (FieldDefinitionTreatment) base.treatment; }
-			set { base.treatment = (uint) value; }
-		}
-
 		public bool HasLayoutInfo {
 			get {
 				if (offset >= 0)
@@ -111,7 +106,7 @@ namespace Mono.Cecil {
 		public FieldAttributes Attributes {
 			get { return (FieldAttributes) attributes; }
 			set {
-				if (Treatment != FieldDefinitionTreatment.None && (ushort) value != attributes)
+				if (projection != null && (ushort) value != attributes)
 					throw new InvalidOperationException ("Projected field definition attributes can't be changed.");
 				attributes = (ushort) value;
 			}

--- a/Mono.Cecil/FieldDefinition.cs
+++ b/Mono.Cecil/FieldDefinition.cs
@@ -63,6 +63,11 @@ namespace Mono.Cecil {
 			set { offset = value; }
 		}
 
+		internal new FieldDefinitionProjection WindowsRuntimeProjection {
+			get { return (FieldDefinitionProjection) projection; }
+			set { projection = value; }
+		}
+
 		void ResolveRVA ()
 		{
 			if (rva != Mixin.NotResolvedMarker)
@@ -106,7 +111,7 @@ namespace Mono.Cecil {
 		public FieldAttributes Attributes {
 			get { return (FieldAttributes) attributes; }
 			set {
-				if (projection != null && (ushort) value != attributes)
+				if (IsWindowsRuntimeProjection && (ushort) value != attributes)
 					throw new InvalidOperationException ("Projected field definition attributes can't be changed.");
 				attributes = (ushort) value;
 			}

--- a/Mono.Cecil/MemberReference.cs
+++ b/Mono.Cecil/MemberReference.cs
@@ -23,7 +23,7 @@ namespace Mono.Cecil {
 		public virtual string Name {
 			get { return name; }
 			set {
-				if (projection != null && value != name)
+				if (IsWindowsRuntimeProjection && value != name)
 					throw new InvalidOperationException ("Projected member reference name can't be changed.");
 				name = value;
 			}
@@ -41,6 +41,15 @@ namespace Mono.Cecil {
 		public MetadataToken MetadataToken {
 			get { return token; }
 			set { token = value; }
+		}
+
+		public bool IsWindowsRuntimeProjection {
+			get { return projection != null; }
+		}
+
+		internal MemberReferenceProjection WindowsRuntimeProjection {
+			get { return (MemberReferenceProjection) projection; }
+			set { projection = value; }
 		}
 
 		internal bool HasImage {

--- a/Mono.Cecil/MemberReference.cs
+++ b/Mono.Cecil/MemberReference.cs
@@ -8,6 +8,8 @@
 // Licensed under the MIT/X11 license.
 //
 
+using System;
+
 namespace Mono.Cecil {
 
 	public abstract class MemberReference : IMetadataTokenProvider {
@@ -16,10 +18,15 @@ namespace Mono.Cecil {
 		TypeReference declaring_type;
 
 		internal MetadataToken token;
+		internal uint treatment = 0;
 
 		public virtual string Name {
 			get { return name; }
-			set { name = value; }
+			set {
+				if (Treatment != MemberReferenceTreatment.None && value != name)
+					throw new InvalidOperationException ("Projected member reference name can't be changed.");
+				name = value;
+			}
 		}
 
 		public abstract string FullName {
@@ -56,6 +63,11 @@ namespace Mono.Cecil {
 
 		public virtual bool ContainsGenericParameter {
 			get { return declaring_type != null && declaring_type.ContainsGenericParameter; }
+		}
+
+		internal MemberReferenceTreatment Treatment {
+			get { return (MemberReferenceTreatment) treatment; }
+			set { treatment = (uint) value; }
 		}
 
 		internal MemberReference ()

--- a/Mono.Cecil/MemberReference.cs
+++ b/Mono.Cecil/MemberReference.cs
@@ -18,12 +18,12 @@ namespace Mono.Cecil {
 		TypeReference declaring_type;
 
 		internal MetadataToken token;
-		internal uint treatment = 0;
+		internal object projection;
 
 		public virtual string Name {
 			get { return name; }
 			set {
-				if (Treatment != MemberReferenceTreatment.None && value != name)
+				if (projection != null && value != name)
 					throw new InvalidOperationException ("Projected member reference name can't be changed.");
 				name = value;
 			}
@@ -63,11 +63,6 @@ namespace Mono.Cecil {
 
 		public virtual bool ContainsGenericParameter {
 			get { return declaring_type != null && declaring_type.ContainsGenericParameter; }
-		}
-
-		internal MemberReferenceTreatment Treatment {
-			get { return (MemberReferenceTreatment) treatment; }
-			set { treatment = (uint) value; }
 		}
 
 		internal MemberReference ()

--- a/Mono.Cecil/MethodDefinition.cs
+++ b/Mono.Cecil/MethodDefinition.cs
@@ -8,6 +8,7 @@
 // Licensed under the MIT/X11 license.
 //
 
+using System;
 using Mono.Cecil.Cil;
 using Mono.Collections.Generic;
 
@@ -30,14 +31,37 @@ namespace Mono.Cecil {
 
 		internal MethodBody body;
 
+		public override string Name
+		{
+			get { return base.Name; }
+			set {
+				if (Treatment != MethodDefinitionTreatment.None && value != base.Name)
+					throw new InvalidOperationException ("Projected method name can't be changed.");
+				base.Name = value;
+			}
+		}
+
 		public MethodAttributes Attributes {
 			get { return (MethodAttributes) attributes; }
-			set { attributes = (ushort) value; }
+			set {
+				if (Treatment != MethodDefinitionTreatment.None && (ushort) value != attributes)
+					throw new InvalidOperationException ("Projected method attributes can't be changed.");
+				attributes = (ushort) value;
+			}
 		}
 
 		public MethodImplAttributes ImplAttributes {
 			get { return (MethodImplAttributes) impl_attributes; }
-			set { impl_attributes = (ushort) value; }
+			set {
+				if (Treatment != MethodDefinitionTreatment.None && (ushort) value != impl_attributes)
+					throw new InvalidOperationException ("Projected method implementation attributes can't be changed.");
+				impl_attributes = (ushort) value;
+			}
+		}
+
+		internal new MethodDefinitionTreatment Treatment {
+			get { return (MethodDefinitionTreatment) base.treatment; }
+			set { base.treatment = (uint) value; }
 		}
 
 		public MethodSemanticsAttributes SemanticsAttributes {

--- a/Mono.Cecil/MethodDefinition.cs
+++ b/Mono.Cecil/MethodDefinition.cs
@@ -35,7 +35,7 @@ namespace Mono.Cecil {
 		{
 			get { return base.Name; }
 			set {
-				if (Treatment != MethodDefinitionTreatment.None && value != base.Name)
+				if (projection != null && value != base.Name)
 					throw new InvalidOperationException ("Projected method name can't be changed.");
 				base.Name = value;
 			}
@@ -44,7 +44,7 @@ namespace Mono.Cecil {
 		public MethodAttributes Attributes {
 			get { return (MethodAttributes) attributes; }
 			set {
-				if (Treatment != MethodDefinitionTreatment.None && (ushort) value != attributes)
+				if (projection != null && (ushort)value != attributes)
 					throw new InvalidOperationException ("Projected method attributes can't be changed.");
 				attributes = (ushort) value;
 			}
@@ -53,15 +53,10 @@ namespace Mono.Cecil {
 		public MethodImplAttributes ImplAttributes {
 			get { return (MethodImplAttributes) impl_attributes; }
 			set {
-				if (Treatment != MethodDefinitionTreatment.None && (ushort) value != impl_attributes)
+				if (projection != null && (ushort)value != impl_attributes)
 					throw new InvalidOperationException ("Projected method implementation attributes can't be changed.");
 				impl_attributes = (ushort) value;
 			}
-		}
-
-		internal new MethodDefinitionTreatment Treatment {
-			get { return (MethodDefinitionTreatment) base.treatment; }
-			set { base.treatment = (uint) value; }
 		}
 
 		public MethodSemanticsAttributes SemanticsAttributes {

--- a/Mono.Cecil/MethodDefinition.cs
+++ b/Mono.Cecil/MethodDefinition.cs
@@ -35,7 +35,7 @@ namespace Mono.Cecil {
 		{
 			get { return base.Name; }
 			set {
-				if (projection != null && value != base.Name)
+				if (IsWindowsRuntimeProjection && value != base.Name)
 					throw new InvalidOperationException ("Projected method name can't be changed.");
 				base.Name = value;
 			}
@@ -44,7 +44,7 @@ namespace Mono.Cecil {
 		public MethodAttributes Attributes {
 			get { return (MethodAttributes) attributes; }
 			set {
-				if (projection != null && (ushort)value != attributes)
+				if (IsWindowsRuntimeProjection && (ushort) value != attributes)
 					throw new InvalidOperationException ("Projected method attributes can't be changed.");
 				attributes = (ushort) value;
 			}
@@ -53,7 +53,7 @@ namespace Mono.Cecil {
 		public MethodImplAttributes ImplAttributes {
 			get { return (MethodImplAttributes) impl_attributes; }
 			set {
-				if (projection != null && (ushort)value != impl_attributes)
+				if (IsWindowsRuntimeProjection && (ushort) value != impl_attributes)
 					throw new InvalidOperationException ("Projected method implementation attributes can't be changed.");
 				impl_attributes = (ushort) value;
 			}
@@ -74,6 +74,11 @@ namespace Mono.Cecil {
 				return sem_attrs;
 			}
 			set { sem_attrs = value; }
+		}
+
+		internal new MethodDefinitionProjection WindowsRuntimeProjection {
+			get { return (MethodDefinitionProjection) projection; }
+			set { projection = value; }
 		}
 
 		internal void ReadSemantics ()

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -40,6 +40,7 @@ namespace Mono.Cecil {
 		Stream symbol_stream;
 		ISymbolReaderProvider symbol_reader_provider;
 		bool read_symbols;
+		bool projections;
 
 		public ReadingMode ReadingMode {
 			get { return reading_mode; }
@@ -83,6 +84,11 @@ namespace Mono.Cecil {
 		public bool ReadSymbols {
 			get { return read_symbols; }
 			set { read_symbols = value; }
+		}
+
+		public bool ApplyWindowsRuntimeProjections {
+			get { return projections; }
+			set { projections = value; }
 		}
 
 		public ReaderParameters ()
@@ -230,6 +236,8 @@ namespace Mono.Cecil {
 
 		internal string runtime_version;
 		internal ModuleKind kind;
+		WindowsRuntimeProjections projections;
+		MetadataKind metadata_kind;
 		TargetRuntime runtime;
 		TargetArchitecture architecture;
 		ModuleAttributes attributes;
@@ -259,6 +267,20 @@ namespace Mono.Cecil {
 		public ModuleKind Kind {
 			get { return kind; }
 			set { kind = value; }
+		}
+
+		public MetadataKind MetadataKind {
+			get { return metadata_kind; }
+			set { metadata_kind = value; }
+		}
+
+		internal WindowsRuntimeProjections Projections {
+			get {
+				if (projections == null)
+					Interlocked.CompareExchange (ref projections, new WindowsRuntimeProjections (this), null);
+
+				return projections;
+			}
 		}
 
 		public TargetRuntime Runtime {

--- a/Mono.Cecil/ModuleKind.cs
+++ b/Mono.Cecil/ModuleKind.cs
@@ -19,6 +19,12 @@ namespace Mono.Cecil {
 		NetModule,
 	}
 
+	public enum MetadataKind {
+		Ecma335,
+		WindowsMetadata,
+		ManagedWindowsMetadata,
+	}
+
 	public enum TargetArchitecture {
 		I386,
 		AMD64,

--- a/Mono.Cecil/Treatments.cs
+++ b/Mono.Cecil/Treatments.cs
@@ -1,0 +1,66 @@
+﻿//
+// Author:
+//   Jb Evain (jbevain@gmail.com)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+//
+// Licensed under the MIT/X11 license.
+//
+
+using System;
+
+namespace Mono.Cecil {
+
+	[Flags]
+	enum TypeDefinitionTreatment {
+		None = 0x0,
+
+		KindMask = 0xf,
+		NormalType = 0x1,
+		NormalAttribute = 0x2,
+		UnmangleWindowsRuntimeName = 0x3,
+		PrefixWindowsRuntimeName = 0x4,
+		RedirectToClrType = 0x5,
+		RedirectToClrAttribute = 0x6,
+
+		Abstract = 0x10,
+		Internal = 0x20,
+	}
+
+	enum TypeReferenceTreatment {
+		None = 0x0,
+		SystemDelegate = 0x1,
+		SystemAttribute = 0x2,
+		UseProjectionInfo = 0x3,
+	}
+
+	[Flags]
+	enum MethodDefinitionTreatment {
+		None = 0x0,
+		Dispose = 0x1,
+		Abstract = 0x2,
+		Private = 0x4,
+		Public = 0x8,
+		Runtime = 0x10,
+		InternalCall = 0x20,
+	}
+
+	enum FieldDefinitionTreatment {
+		None = 0x0,
+		Public = 0x1,
+	}
+
+	enum MemberReferenceTreatment {
+		None = 0x0,
+		Dispose = 0x1,
+	}
+
+	enum CustomAttributeValueTreatment {
+		None = 0x0,
+		AllowSingle = 0x1,
+		AllowMultiple = 0x2,
+		VersionAttribute = 0x3,
+		DeprecatedAttribute = 0x4,
+	}
+}

--- a/Mono.Cecil/TypeDefinition.cs
+++ b/Mono.Cecil/TypeDefinition.cs
@@ -37,7 +37,7 @@ namespace Mono.Cecil {
 		public TypeAttributes Attributes {
 			get { return (TypeAttributes) attributes; }
 			set {
-				if (projection != null && (ushort) value != attributes)
+				if (IsWindowsRuntimeProjection && (ushort) value != attributes)
 					throw new InvalidOperationException ("Projected type definition attributes can't be changed.");
 				attributes = (uint) value;
 			}
@@ -51,7 +51,7 @@ namespace Mono.Cecil {
 		public override string Name {
 			get { return base.Name; }
 			set {
-				if (projection != null && value != base.Name)
+				if (IsWindowsRuntimeProjection && value != base.Name)
 					throw new InvalidOperationException ("Projected type definition name can't be changed.");
 				base.Name = value;
 			}
@@ -440,6 +440,11 @@ namespace Mono.Cecil {
 		public new TypeDefinition DeclaringType {
 			get { return (TypeDefinition) base.DeclaringType; }
 			set { base.DeclaringType = value; }
+		}
+
+		internal new TypeDefinitionProjection WindowsRuntimeProjection {
+			get { return (TypeDefinitionProjection) projection; }
+			set { projection = value; }
 		}
 
 		public TypeDefinition (string @namespace, string name, TypeAttributes attributes)

--- a/Mono.Cecil/TypeDefinition.cs
+++ b/Mono.Cecil/TypeDefinition.cs
@@ -37,7 +37,7 @@ namespace Mono.Cecil {
 		public TypeAttributes Attributes {
 			get { return (TypeAttributes) attributes; }
 			set {
-				if (Treatment != TypeDefinitionTreatment.None && (ushort) value != attributes)
+				if (projection != null && (ushort) value != attributes)
 					throw new InvalidOperationException ("Projected type definition attributes can't be changed.");
 				attributes = (uint) value;
 			}
@@ -51,7 +51,7 @@ namespace Mono.Cecil {
 		public override string Name {
 			get { return base.Name; }
 			set {
-				if (Treatment != TypeDefinitionTreatment.None && value != base.Name)
+				if (projection != null && value != base.Name)
 					throw new InvalidOperationException ("Projected type definition name can't be changed.");
 				base.Name = value;
 			}
@@ -272,11 +272,6 @@ namespace Mono.Cecil {
 
 		public override Collection<GenericParameter> GenericParameters {
 			get { return generic_parameters ?? (this.GetGenericParameters (ref generic_parameters, Module)); }
-		}
-
-		internal new TypeDefinitionTreatment Treatment {
-			get { return (TypeDefinitionTreatment) base.treatment; }
-			set { base.treatment = (uint) value; }
 		}
 
 		#region TypeAttributes

--- a/Mono.Cecil/TypeDefinition.cs
+++ b/Mono.Cecil/TypeDefinition.cs
@@ -36,12 +36,25 @@ namespace Mono.Cecil {
 
 		public TypeAttributes Attributes {
 			get { return (TypeAttributes) attributes; }
-			set { attributes = (uint) value; }
+			set {
+				if (Treatment != TypeDefinitionTreatment.None && (ushort) value != attributes)
+					throw new InvalidOperationException ("Projected type definition attributes can't be changed.");
+				attributes = (uint) value;
+			}
 		}
 
 		public TypeReference BaseType {
 			get { return base_type; }
 			set { base_type = value; }
+		}
+
+		public override string Name {
+			get { return base.Name; }
+			set {
+				if (Treatment != TypeDefinitionTreatment.None && value != base.Name)
+					throw new InvalidOperationException ("Projected type definition name can't be changed.");
+				base.Name = value;
+			}
 		}
 
 		void ResolveLayout ()
@@ -259,6 +272,11 @@ namespace Mono.Cecil {
 
 		public override Collection<GenericParameter> GenericParameters {
 			get { return generic_parameters ?? (this.GetGenericParameters (ref generic_parameters, Module)); }
+		}
+
+		internal new TypeDefinitionTreatment Treatment {
+			get { return (TypeDefinitionTreatment) base.treatment; }
+			set { base.treatment = (uint) value; }
 		}
 
 		#region TypeAttributes

--- a/Mono.Cecil/TypeReference.cs
+++ b/Mono.Cecil/TypeReference.cs
@@ -65,6 +65,8 @@ namespace Mono.Cecil {
 		public override string Name {
 			get { return base.Name; }
 			set {
+				if (Treatment != TypeReferenceTreatment.None && value != base.Name)
+					throw new InvalidOperationException ("Projected type reference name can't be changed.");
 				base.Name = value;
 				fullname = null;
 			}
@@ -73,6 +75,8 @@ namespace Mono.Cecil {
 		public virtual string Namespace {
 			get { return @namespace; }
 			set {
+				if (Treatment != TypeReferenceTreatment.None && value != @namespace)
+					throw new InvalidOperationException ("Projected type reference namespace can't be changed.");
 				@namespace = value;
 				fullname = null;
 			}
@@ -132,10 +136,14 @@ namespace Mono.Cecil {
 			set {
 				var declaring_type = this.DeclaringType;
 				if (declaring_type != null) {
+					if (Treatment != TypeReferenceTreatment.None && value != declaring_type.Scope)
+						throw new InvalidOperationException ("Projected type scope can't be changed.");
 					declaring_type.Scope = value;
 					return;
 				}
 
+				if (Treatment != TypeReferenceTreatment.None && value != scope)
+					throw new InvalidOperationException ("Projected type scope can't be changed.");
 				scope = value;
 			}
 		}
@@ -147,6 +155,8 @@ namespace Mono.Cecil {
 		public override TypeReference DeclaringType {
 			get { return base.DeclaringType; }
 			set {
+				if (Treatment != TypeReferenceTreatment.None && value != base.DeclaringType)
+					throw new InvalidOperationException ("Projected type declaring type can't be changed.");
 				base.DeclaringType = value;
 				fullname = null;
 			}
@@ -219,6 +229,11 @@ namespace Mono.Cecil {
 					return (MetadataType) etype;
 				}
 			}
+		}
+
+		internal new TypeReferenceTreatment Treatment {
+			get { return (TypeReferenceTreatment) base.treatment; }
+			set { base.treatment = (uint) value; }
 		}
 
 		protected TypeReference (string @namespace, string name)

--- a/Mono.Cecil/TypeReference.cs
+++ b/Mono.Cecil/TypeReference.cs
@@ -65,7 +65,7 @@ namespace Mono.Cecil {
 		public override string Name {
 			get { return base.Name; }
 			set {
-				if (Treatment != TypeReferenceTreatment.None && value != base.Name)
+				if (projection != null && value != base.Name)
 					throw new InvalidOperationException ("Projected type reference name can't be changed.");
 				base.Name = value;
 				fullname = null;
@@ -75,7 +75,7 @@ namespace Mono.Cecil {
 		public virtual string Namespace {
 			get { return @namespace; }
 			set {
-				if (Treatment != TypeReferenceTreatment.None && value != @namespace)
+				if (projection != null && value != @namespace)
 					throw new InvalidOperationException ("Projected type reference namespace can't be changed.");
 				@namespace = value;
 				fullname = null;
@@ -136,13 +136,13 @@ namespace Mono.Cecil {
 			set {
 				var declaring_type = this.DeclaringType;
 				if (declaring_type != null) {
-					if (Treatment != TypeReferenceTreatment.None && value != declaring_type.Scope)
+					if (projection != null && value != declaring_type.Scope)
 						throw new InvalidOperationException ("Projected type scope can't be changed.");
 					declaring_type.Scope = value;
 					return;
 				}
 
-				if (Treatment != TypeReferenceTreatment.None && value != scope)
+				if (projection != null && value != scope)
 					throw new InvalidOperationException ("Projected type scope can't be changed.");
 				scope = value;
 			}
@@ -155,7 +155,7 @@ namespace Mono.Cecil {
 		public override TypeReference DeclaringType {
 			get { return base.DeclaringType; }
 			set {
-				if (Treatment != TypeReferenceTreatment.None && value != base.DeclaringType)
+				if (projection != null && value != base.DeclaringType)
 					throw new InvalidOperationException ("Projected type declaring type can't be changed.");
 				base.DeclaringType = value;
 				fullname = null;
@@ -229,11 +229,6 @@ namespace Mono.Cecil {
 					return (MetadataType) etype;
 				}
 			}
-		}
-
-		internal new TypeReferenceTreatment Treatment {
-			get { return (TypeReferenceTreatment) base.treatment; }
-			set { base.treatment = (uint) value; }
 		}
 
 		protected TypeReference (string @namespace, string name)

--- a/Mono.Cecil/TypeReference.cs
+++ b/Mono.Cecil/TypeReference.cs
@@ -65,7 +65,7 @@ namespace Mono.Cecil {
 		public override string Name {
 			get { return base.Name; }
 			set {
-				if (projection != null && value != base.Name)
+				if (IsWindowsRuntimeProjection && value != base.Name)
 					throw new InvalidOperationException ("Projected type reference name can't be changed.");
 				base.Name = value;
 				fullname = null;
@@ -75,7 +75,7 @@ namespace Mono.Cecil {
 		public virtual string Namespace {
 			get { return @namespace; }
 			set {
-				if (projection != null && value != @namespace)
+				if (IsWindowsRuntimeProjection && value != @namespace)
 					throw new InvalidOperationException ("Projected type reference namespace can't be changed.");
 				@namespace = value;
 				fullname = null;
@@ -98,6 +98,11 @@ namespace Mono.Cecil {
 
 				return null;
 			}
+		}
+
+		internal new TypeReferenceProjection WindowsRuntimeProjection {
+			get { return (TypeReferenceProjection) projection; }
+			set { projection = value; }
 		}
 
 		IGenericParameterProvider IGenericContext.Type {
@@ -136,13 +141,13 @@ namespace Mono.Cecil {
 			set {
 				var declaring_type = this.DeclaringType;
 				if (declaring_type != null) {
-					if (projection != null && value != declaring_type.Scope)
+					if (IsWindowsRuntimeProjection && value != declaring_type.Scope)
 						throw new InvalidOperationException ("Projected type scope can't be changed.");
 					declaring_type.Scope = value;
 					return;
 				}
 
-				if (projection != null && value != scope)
+				if (IsWindowsRuntimeProjection && value != scope)
 					throw new InvalidOperationException ("Projected type scope can't be changed.");
 				scope = value;
 			}
@@ -155,7 +160,7 @@ namespace Mono.Cecil {
 		public override TypeReference DeclaringType {
 			get { return base.DeclaringType; }
 			set {
-				if (projection != null && value != base.DeclaringType)
+				if (IsWindowsRuntimeProjection && value != base.DeclaringType)
 					throw new InvalidOperationException ("Projected type declaring type can't be changed.");
 				base.DeclaringType = value;
 				fullname = null;

--- a/Mono.Cecil/WindowsRuntimeProjections.cs
+++ b/Mono.Cecil/WindowsRuntimeProjections.cs
@@ -1,0 +1,884 @@
+﻿//
+// Author:
+//   Jb Evain (jbevain@gmail.com)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+//
+// Licensed under the MIT/X11 license.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Mono.Collections.Generic;
+
+namespace Mono.Cecil {
+
+	class WindowsRuntimeProjections {
+
+		struct ProjectionInfo {
+
+			public readonly string WinRTNamespace;
+			public readonly string ClrNamespace;
+			public readonly string ClrName;
+			public readonly string ClrAssembly;
+			public readonly bool Attribute;
+			public readonly bool Disposable;
+
+			public ProjectionInfo (string winrt_namespace, string clr_namespace, string clr_name, string clr_assembly, bool attribute = false, bool disposable = false)
+			{
+				WinRTNamespace = winrt_namespace;
+				ClrNamespace = clr_namespace;
+				ClrName = clr_name;
+				ClrAssembly = clr_assembly;
+				Attribute = attribute;
+				Disposable = disposable;
+			}
+		}
+
+		struct TypeDefinitionInfo {
+
+			public readonly TypeAttributes Attributes;
+			public readonly string Name;
+
+			public TypeDefinitionInfo (TypeDefinition type)
+			{
+				Attributes = type.Attributes;
+				Name = type.Name;
+			}
+		}
+
+		struct TypeReferenceInfo {
+
+			public readonly string Name;
+			public readonly string Namespace;
+			public readonly IMetadataScope Scope;
+
+			public TypeReferenceInfo (TypeReference type)
+			{
+				Name = type.Name;
+				Namespace = type.Namespace;
+				Scope = type.Scope;
+			}
+		}
+
+		struct MethodDefinitionInfo {
+
+			public readonly MethodAttributes Attributes;
+			public readonly MethodImplAttributes ImplAttributes;
+			public readonly string Name;
+
+			public MethodDefinitionInfo (MethodDefinition method)
+			{
+				Attributes = method.Attributes;
+				ImplAttributes = method.ImplAttributes;
+				Name = method.Name;
+			}
+		}
+
+		static readonly Version version = new Version (4, 0, 0, 0);
+
+		static readonly byte[] contract_pk_token = {
+			0xB0, 0x3F, 0x5F, 0x7F, 0x11, 0xD5, 0x0A, 0x3A
+		};
+
+		static readonly byte[] contract_pk = {
+			0x00, 0x24, 0x00, 0x00, 0x04, 0x80, 0x00, 0x00, 0x94, 0x00, 0x00, 0x00, 0x06, 0x02, 0x00, 0x00,
+			0x00, 0x24, 0x00, 0x00, 0x52, 0x53, 0x41, 0x31, 0x00, 0x04, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+			0x07, 0xD1, 0xFA, 0x57, 0xC4, 0xAE, 0xD9, 0xF0, 0xA3, 0x2E, 0x84, 0xAA, 0x0F, 0xAE, 0xFD, 0x0D,
+			0xE9, 0xE8, 0xFD, 0x6A, 0xEC, 0x8F, 0x87, 0xFB, 0x03, 0x76, 0x6C, 0x83, 0x4C, 0x99, 0x92, 0x1E,
+			0xB2, 0x3B, 0xE7, 0x9A, 0xD9, 0xD5, 0xDC, 0xC1, 0xDD, 0x9A, 0xD2, 0x36, 0x13, 0x21, 0x02, 0x90,
+			0x0B, 0x72, 0x3C, 0xF9, 0x80, 0x95, 0x7F, 0xC4, 0xE1, 0x77, 0x10, 0x8F, 0xC6, 0x07, 0x77, 0x4F,
+			0x29, 0xE8, 0x32, 0x0E, 0x92, 0xEA, 0x05, 0xEC, 0xE4, 0xE8, 0x21, 0xC0, 0xA5, 0xEF, 0xE8, 0xF1,
+			0x64, 0x5C, 0x4C, 0x0C, 0x93, 0xC1, 0xAB, 0x99, 0x28, 0x5D, 0x62, 0x2C, 0xAA, 0x65, 0x2C, 0x1D,
+			0xFA, 0xD6, 0x3D, 0x74, 0x5D, 0x6F, 0x2D, 0xE5, 0xF1, 0x7E, 0x5E, 0xAF, 0x0F, 0xC4, 0x96, 0x3D,
+			0x26, 0x1C, 0x8A, 0x12, 0x43, 0x65, 0x18, 0x20, 0x6D, 0xC0, 0x93, 0x34, 0x4D, 0x5A, 0xD2, 0x93
+		};
+
+		static Dictionary<string, ProjectionInfo> projections;
+
+		static Dictionary<string, ProjectionInfo> Projections
+		{
+			get {
+				if (projections == null) {
+					projections = new Dictionary<string, ProjectionInfo> {
+						{ "AttributeTargets", new ProjectionInfo ("Windows.Foundation.Metadata", "System", "AttributeTargets", "System.Runtime") },
+						{ "AttributeUsageAttribute", new ProjectionInfo ("Windows.Foundation.Metadata", "System", "AttributeUsageAttribute", "System.Runtime", attribute: true) },
+						{ "Color", new ProjectionInfo ("Windows.UI", "Windows.UI", "Color", "System.Runtime.WindowsRuntime") },
+						{ "CornerRadius", new ProjectionInfo ("Windows.UI.Xaml", "Windows.UI.Xaml", "CornerRadius", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "DateTime", new ProjectionInfo ("Windows.Foundation", "System", "DateTimeOffset", "System.Runtime") },
+						{ "Duration", new ProjectionInfo ("Windows.UI.Xaml", "Windows.UI.Xaml", "Duration", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "DurationType", new ProjectionInfo ("Windows.UI.Xaml", "Windows.UI.Xaml", "DurationType", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "EventHandler`1", new ProjectionInfo ("Windows.Foundation", "System", "EventHandler`1", "System.Runtime") },
+						{ "EventRegistrationToken", new ProjectionInfo ("Windows.Foundation", "System.Runtime.InteropServices.WindowsRuntime", "EventRegistrationToken", "System.Runtime.InteropServices.WindowsRuntime") },
+						{ "GeneratorPosition", new ProjectionInfo ("Windows.UI.Xaml.Controls.Primitives", "Windows.UI.Xaml.Controls.Primitives", "GeneratorPosition", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "GridLength", new ProjectionInfo ("Windows.UI.Xaml", "Windows.UI.Xaml", "GridLength", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "GridUnitType", new ProjectionInfo ("Windows.UI.Xaml", "Windows.UI.Xaml", "GridUnitType", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "HResult", new ProjectionInfo ("Windows.Foundation", "System", "Exception", "System.Runtime") },
+						{ "IBindableIterable", new ProjectionInfo ("Windows.UI.Xaml.Interop", "System.Collections", "IEnumerable", "System.Runtime") },
+						{ "IBindableVector", new ProjectionInfo ("Windows.UI.Xaml.Interop", "System.Collections", "IList", "System.Runtime") },
+						{ "IClosable", new ProjectionInfo ("Windows.Foundation", "System", "IDisposable", "System.Runtime", disposable: true) },
+						{ "ICommand", new ProjectionInfo ("Windows.UI.Xaml.Input", "System.Windows.Input", "ICommand", "System.ObjectModel") },
+						{ "IIterable`1", new ProjectionInfo ("Windows.Foundation.Collections", "System.Collections.Generic", "IEnumerable`1", "System.Runtime") },
+						{ "IKeyValuePair`2", new ProjectionInfo ("Windows.Foundation.Collections", "System.Collections.Generic", "KeyValuePair`2", "System.Runtime") },
+						{ "IMapView`2", new ProjectionInfo ("Windows.Foundation.Collections", "System.Collections.Generic", "IReadOnlyDictionary`2", "System.Runtime") },
+						{ "IMap`2", new ProjectionInfo ("Windows.Foundation.Collections", "System.Collections.Generic", "IDictionary`2", "System.Runtime") },
+						{ "INotifyCollectionChanged", new ProjectionInfo ("Windows.UI.Xaml.Interop", "System.Collections.Specialized", "INotifyCollectionChanged", "System.ObjectModel") },
+						{ "INotifyPropertyChanged", new ProjectionInfo ("Windows.UI.Xaml.Data", "System.ComponentModel", "INotifyPropertyChanged", "System.ObjectModel") },
+						{ "IReference`1", new ProjectionInfo ("Windows.Foundation", "System", "Nullable`1", "System.Runtime") },
+						{ "IVectorView`1", new ProjectionInfo ("Windows.Foundation.Collections", "System.Collections.Generic", "IReadOnlyList`1", "System.Runtime") },
+						{ "IVector`1", new ProjectionInfo ("Windows.Foundation.Collections", "System.Collections.Generic", "IList`1", "System.Runtime") },
+						{ "KeyTime", new ProjectionInfo ("Windows.UI.Xaml.Media.Animation", "Windows.UI.Xaml.Media.Animation", "KeyTime", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "Matrix", new ProjectionInfo ("Windows.UI.Xaml.Media", "Windows.UI.Xaml.Media", "Matrix", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "Matrix3D", new ProjectionInfo ("Windows.UI.Xaml.Media.Media3D", "Windows.UI.Xaml.Media.Media3D", "Matrix3D", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "Matrix3x2", new ProjectionInfo ("Windows.Foundation.Numerics", "System.Numerics", "Matrix3x2", "System.Numerics.Vectors") },
+						{ "Matrix4x4", new ProjectionInfo ("Windows.Foundation.Numerics", "System.Numerics", "Matrix4x4", "System.Numerics.Vectors") },
+						{ "NotifyCollectionChangedAction", new ProjectionInfo ("Windows.UI.Xaml.Interop", "System.Collections.Specialized", "NotifyCollectionChangedAction", "System.ObjectModel") },
+						{ "NotifyCollectionChangedEventArgs", new ProjectionInfo ("Windows.UI.Xaml.Interop", "System.Collections.Specialized", "NotifyCollectionChangedEventArgs", "System.ObjectModel") },
+						{ "NotifyCollectionChangedEventHandler", new ProjectionInfo ("Windows.UI.Xaml.Interop", "System.Collections.Specialized", "NotifyCollectionChangedEventHandler", "System.ObjectModel") },
+						{ "Plane", new ProjectionInfo ("Windows.Foundation.Numerics", "System.Numerics", "Plane", "System.Numerics.Vectors") },
+						{ "Point", new ProjectionInfo ("Windows.Foundation", "Windows.Foundation", "Point", "System.Runtime.WindowsRuntime") },
+						{ "PropertyChangedEventArgs", new ProjectionInfo ("Windows.UI.Xaml.Data", "System.ComponentModel", "PropertyChangedEventArgs", "System.ObjectModel") },
+						{ "PropertyChangedEventHandler", new ProjectionInfo ("Windows.UI.Xaml.Data", "System.ComponentModel", "PropertyChangedEventHandler", "System.ObjectModel") },
+						{ "Quaternion", new ProjectionInfo ("Windows.Foundation.Numerics", "System.Numerics", "Quaternion", "System.Numerics.Vectors") },
+						{ "Rect", new ProjectionInfo ("Windows.Foundation", "Windows.Foundation", "Rect", "System.Runtime.WindowsRuntime") },
+						{ "RepeatBehavior", new ProjectionInfo ("Windows.UI.Xaml.Media.Animation", "Windows.UI.Xaml.Media.Animation", "RepeatBehavior", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "RepeatBehaviorType", new ProjectionInfo ("Windows.UI.Xaml.Media.Animation", "Windows.UI.Xaml.Media.Animation", "RepeatBehaviorType", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "Size", new ProjectionInfo ("Windows.Foundation", "Windows.Foundation", "Size", "System.Runtime.WindowsRuntime") },
+						{ "Thickness", new ProjectionInfo ("Windows.UI.Xaml", "Windows.UI.Xaml", "Thickness", "System.Runtime.WindowsRuntime.UI.Xaml") },
+						{ "TimeSpan", new ProjectionInfo ("Windows.Foundation", "System", "TimeSpan", "System.Runtime") },
+						{ "TypeName", new ProjectionInfo ("Windows.UI.Xaml.Interop", "System", "Type", "System.Runtime") },
+						{ "Uri", new ProjectionInfo ("Windows.Foundation", "System", "Uri", "System.Runtime") },
+						{ "Vector2", new ProjectionInfo ("Windows.Foundation.Numerics", "System.Numerics", "Vector2", "System.Numerics.Vectors") },
+						{ "Vector3", new ProjectionInfo ("Windows.Foundation.Numerics", "System.Numerics", "Vector3", "System.Numerics.Vectors") },
+						{ "Vector4", new ProjectionInfo ("Windows.Foundation.Numerics", "System.Numerics", "Vector4", "System.Numerics.Vectors") },
+					};
+				}
+
+				return projections;
+			}
+		}
+
+		readonly ModuleDefinition module;
+		Version corlib_version = new Version (255, 255, 255, 255);
+		AssemblyNameReference[] virtual_references;
+		Dictionary<uint, TypeDefinitionInfo> types;
+		Dictionary<uint, TypeReferenceInfo> type_references;
+		Dictionary<uint, MethodDefinitionInfo> methods;
+		Dictionary<uint, FieldAttributes> fields;
+		Dictionary<uint, AttributeTargets> attributes;
+
+		AssemblyNameReference[] VirtualReferences {
+			get {
+				if (virtual_references == null) {
+					// force module to read its assembly references. that will in turn initialze virtual_references
+					var temp = module.AssemblyReferences;
+				}
+
+				return virtual_references;
+			}
+		}
+
+		Dictionary<uint, TypeDefinitionInfo> Types {
+			get
+			{
+				if (types == null)
+					Interlocked.CompareExchange(ref types, new Dictionary<uint, TypeDefinitionInfo> (), null);
+
+				return types;
+			}
+		}
+
+		Dictionary<uint, TypeReferenceInfo> TypeReferences {
+			get {
+				if (type_references == null)
+					Interlocked.CompareExchange (ref type_references, new Dictionary<uint, TypeReferenceInfo> (), null);
+
+				return type_references;
+			}
+		}
+
+		Dictionary<uint, MethodDefinitionInfo> Methods {
+			get {
+				if (methods == null)
+					Interlocked.CompareExchange(ref methods, new Dictionary<uint, MethodDefinitionInfo> (), null);
+
+				return methods;
+			}
+		}
+
+		Dictionary<uint, FieldAttributes> Fields {
+			get {
+				if (fields == null)
+					Interlocked.CompareExchange (ref fields, new Dictionary<uint, FieldAttributes> (), null);
+
+				return fields;
+			}
+		}
+
+		Dictionary<uint, AttributeTargets> Attributes {
+			get {
+				if (attributes == null)
+					Interlocked.CompareExchange (ref attributes, new Dictionary<uint, AttributeTargets> (), null);
+
+				return attributes;
+			}
+		}
+
+		public WindowsRuntimeProjections (ModuleDefinition module)
+		{
+			this.module = module;
+		}
+
+		#region TypeDefinition
+
+		public void Project (TypeDefinition type)
+		{
+			var treatment = TypeDefinitionTreatment.None;
+			var metadata_kind = type.Module.MetadataKind;
+
+			if (type.IsWindowsRuntime) {
+				if (metadata_kind == MetadataKind.WindowsMetadata) {
+					treatment = GetWellKnownTypeDefinitionTreatment (type);
+					if (treatment != TypeDefinitionTreatment.None) {
+						ApplyTreatment (type, treatment);
+						return;
+					}
+
+					var base_type = type.BaseType;
+					if (base_type != null && IsAttribute (base_type))
+						treatment = TypeDefinitionTreatment.NormalAttribute;
+					else
+						treatment = TypeDefinitionTreatment.NormalType;
+				}
+				else if (metadata_kind == MetadataKind.ManagedWindowsMetadata && NeedsWindowsRuntimePrefix (type))
+					treatment = TypeDefinitionTreatment.PrefixWindowsRuntimeName;
+
+				if (treatment == TypeDefinitionTreatment.PrefixWindowsRuntimeName || treatment == TypeDefinitionTreatment.NormalType)
+					if (!type.IsInterface && HasAttribute (type, "Windows.UI.Xaml", "TreatAsAbstractComposableClassAttribute"))
+						treatment |= TypeDefinitionTreatment.Abstract;
+			}
+			else if (metadata_kind == MetadataKind.ManagedWindowsMetadata && IsClrImplementationType (type))
+				treatment = TypeDefinitionTreatment.UnmangleWindowsRuntimeName;
+
+			if (treatment != TypeDefinitionTreatment.None)
+				ApplyTreatment (type, treatment);
+		}
+
+		static TypeDefinitionTreatment GetWellKnownTypeDefinitionTreatment (TypeDefinition type)
+		{
+			ProjectionInfo info;
+			if (!Projections.TryGetValue (type.Name, out info))
+				return TypeDefinitionTreatment.None;
+
+			var treatment = info.Attribute ? TypeDefinitionTreatment.RedirectToClrAttribute : TypeDefinitionTreatment.RedirectToClrType;
+
+			if (type.Namespace == info.ClrNamespace)
+				return treatment;
+
+			if (type.Namespace == info.WinRTNamespace)
+				return treatment | TypeDefinitionTreatment.Internal;
+
+			return TypeDefinitionTreatment.None;
+		}
+
+		static bool NeedsWindowsRuntimePrefix (TypeDefinition type)
+		{
+			if ((type.Attributes & (TypeAttributes.VisibilityMask | TypeAttributes.Interface)) != TypeAttributes.Public)
+				return false;
+
+			var base_type = type.BaseType;
+			if (base_type == null || base_type.MetadataToken.TokenType != TokenType.TypeRef)
+				return false;
+
+			if (base_type.Namespace == "System")
+				switch (base_type.Name)
+				{
+					case "Attribute":
+					case "MulticastDelegate":
+					case "ValueType":
+						return false;
+				}
+
+			return true;
+		}
+
+		static bool IsClrImplementationType (TypeDefinition type)
+		{
+			if ((type.Attributes & (TypeAttributes.VisibilityMask | TypeAttributes.SpecialName)) != TypeAttributes.SpecialName)
+				return false;
+			return type.Name.StartsWith ("<CLR>");
+		}
+
+		public void ApplyTreatment (TypeDefinition type, TypeDefinitionTreatment treatment)
+		{
+			Types [type.MetadataToken.RID] = new TypeDefinitionInfo (type);
+
+			switch (treatment & TypeDefinitionTreatment.KindMask) {
+			case TypeDefinitionTreatment.NormalType:
+				type.Attributes |= TypeAttributes.WindowsRuntime | TypeAttributes.Import;
+				break;
+
+			case TypeDefinitionTreatment.NormalAttribute:
+				type.Attributes |= TypeAttributes.WindowsRuntime | TypeAttributes.Sealed;
+				break;
+
+			case TypeDefinitionTreatment.UnmangleWindowsRuntimeName:
+				type.Attributes = type.Attributes & ~TypeAttributes.SpecialName | TypeAttributes.Public;
+				type.Name = type.Name.Substring ("<CLR>".Length);
+				break;
+
+			case TypeDefinitionTreatment.PrefixWindowsRuntimeName:
+				type.Attributes = type.Attributes & ~TypeAttributes.Public | TypeAttributes.Import;
+				type.Name = "<WinRT>" + type.Name;
+				break;
+
+			case TypeDefinitionTreatment.RedirectToClrType:
+				type.Attributes = type.Attributes & ~TypeAttributes.Public | TypeAttributes.Import;
+				break;
+
+			case TypeDefinitionTreatment.RedirectToClrAttribute:
+				type.Attributes = type.Attributes & ~TypeAttributes.Public;
+				break;
+			}
+
+			if ((treatment & TypeDefinitionTreatment.Abstract) != 0)
+				type.Attributes |= TypeAttributes.Abstract;
+
+			if ((treatment & TypeDefinitionTreatment.Internal) != 0)
+				type.Attributes &= ~TypeAttributes.Public;
+
+			type.Treatment = treatment;
+		}
+
+		public void RemoveTreatment (TypeDefinition type)
+		{
+			var info = Types [type.MetadataToken.RID];
+			Types.Remove (type.MetadataToken.RID);
+
+			type.Treatment = TypeDefinitionTreatment.None;
+
+			type.Attributes = info.Attributes;
+			type.Name = info.Name;
+		}
+
+		#endregion
+
+		#region TypeReference
+
+		public void Project (TypeReference type)
+		{
+			TypeReferenceTreatment treatment;
+
+			ProjectionInfo info;
+			if (Projections.TryGetValue (type.Name, out info) && info.WinRTNamespace == type.Namespace)
+				treatment = TypeReferenceTreatment.UseProjectionInfo;
+			else
+				treatment = GetSpecialTypeReferenceTreatment (type);
+
+			if (treatment != TypeReferenceTreatment.None)
+				ApplyTreatment (type, treatment);
+		}
+
+		static TypeReferenceTreatment GetSpecialTypeReferenceTreatment (TypeReference type)
+		{
+			if (type.Namespace == "System") {
+				if (type.Name == "MulticastDelegate")
+					return TypeReferenceTreatment.SystemDelegate;
+				if (type.Name == "Attribute")
+					return TypeReferenceTreatment.SystemAttribute;
+			}
+
+			return TypeReferenceTreatment.None;
+		}
+
+		static bool IsAttribute (TypeReference type)
+		{
+			if (type.MetadataToken.TokenType != TokenType.TypeRef)
+				return false;
+			return type.Name == "Attribute" && type.Namespace == "System";
+		}
+
+		static bool IsEnum (TypeReference type)
+		{
+			if (type.MetadataToken.TokenType != TokenType.TypeRef)
+				return false;
+			return type.Name == "Enum" && type.Namespace == "System";
+		}
+
+		public void ApplyTreatment (TypeReference type, TypeReferenceTreatment treatment)
+		{
+			TypeReferences [type.MetadataToken.RID] = new TypeReferenceInfo (type);
+
+			switch (treatment)
+			{
+				case TypeReferenceTreatment.SystemDelegate:
+				case TypeReferenceTreatment.SystemAttribute:
+					type.Scope = GetAssemblyReference ("System.Runtime");
+					break;
+
+				case TypeReferenceTreatment.UseProjectionInfo:
+					var info = Projections [type.Name];
+					type.Name = info.ClrName;
+					type.Namespace = info.ClrNamespace;
+					type.Scope = GetAssemblyReference (info.ClrAssembly);
+					break;
+			}
+
+			type.Treatment = treatment;
+		}
+
+		public void RemoveTreatment (TypeReference type)
+		{
+			var info = TypeReferences [type.MetadataToken.RID];
+			TypeReferences.Remove (type.MetadataToken.RID);
+
+			type.Treatment = TypeReferenceTreatment.None;
+
+			type.Name = info.Name;
+			type.Namespace = info.Namespace;
+			type.Scope = info.Scope;
+		}
+
+		#endregion
+
+		#region MethodDefinition
+
+		public void Project (MethodDefinition method)
+		{
+			var treatment = MethodDefinitionTreatment.None;
+			var other = false;
+			var declaring_type = method.DeclaringType;
+
+			if (declaring_type.IsWindowsRuntime)
+			{
+				if (IsClrImplementationType (declaring_type))
+					treatment = MethodDefinitionTreatment.None;
+				else if (declaring_type.IsNested)
+					treatment = MethodDefinitionTreatment.None;
+				else if (declaring_type.IsInterface)
+					treatment = MethodDefinitionTreatment.Runtime | MethodDefinitionTreatment.InternalCall;
+				else if (declaring_type.Module.MetadataKind == MetadataKind.ManagedWindowsMetadata && !method.IsPublic)
+					treatment = MethodDefinitionTreatment.None;
+				else
+				{
+					other = true;
+
+					var base_type = declaring_type.BaseType;
+					if (base_type != null && base_type.MetadataToken.TokenType == TokenType.TypeRef)
+					{
+						switch (GetSpecialTypeReferenceTreatment(base_type))
+						{
+							case TypeReferenceTreatment.SystemDelegate:
+								treatment = MethodDefinitionTreatment.Runtime | MethodDefinitionTreatment.Public;
+								other = false;
+								break;
+
+							case TypeReferenceTreatment.SystemAttribute:
+								treatment = MethodDefinitionTreatment.Runtime | MethodDefinitionTreatment.InternalCall;
+								other = false;
+								break;
+						}
+					}
+				}
+			}
+
+			if (other)
+			{
+				var seen_redirected = false;
+				var seen_non_redirected = false;
+				var disposable = false;
+
+				foreach (var @override in method.Overrides)
+				{
+					if (@override.MetadataToken.TokenType == TokenType.MemberRef && ImplementsRedirectedInterface (@override, out disposable))
+					{
+						seen_redirected = true;
+						if (disposable)
+							break;
+					}
+					else
+						seen_non_redirected = true;
+				}
+
+				if (disposable)
+				{
+					treatment = MethodDefinitionTreatment.Dispose;
+					other = false;
+				}
+				else if (seen_redirected && !seen_non_redirected)
+				{
+					treatment = MethodDefinitionTreatment.Runtime | MethodDefinitionTreatment.InternalCall | MethodDefinitionTreatment.Private;
+					other = false;
+				}
+			}
+
+			if (other)
+				treatment |= GetMethodDefinitionTreatmentFromCustomAttributes(method);
+
+			if (treatment != MethodDefinitionTreatment.None)
+				method.Module.Projections.ApplyTreatment (method, treatment);
+		}
+
+		static MethodDefinitionTreatment GetMethodDefinitionTreatmentFromCustomAttributes(MethodDefinition method)
+		{
+			var treatment = MethodDefinitionTreatment.None;
+
+			foreach (var attribute in method.CustomAttributes)
+			{
+				var type = attribute.AttributeType;
+				if (type.Namespace != "Windows.UI.Xaml")
+					continue;
+				if (type.Name == "TreatAsPublicMethodAttribute")
+					treatment |= MethodDefinitionTreatment.Public;
+				else if (type.Name == "TreatAsAbstractMethodAttribute")
+					treatment |= MethodDefinitionTreatment.Abstract;
+			}
+
+			return treatment;
+		}
+
+		public void ApplyTreatment (MethodDefinition method, MethodDefinitionTreatment treatment)
+		{
+			Methods [method.MetadataToken.RID] = new MethodDefinitionInfo (method);
+
+			if ((treatment & MethodDefinitionTreatment.Dispose) != 0)
+				method.Name = "Dispose";
+
+			if ((treatment & MethodDefinitionTreatment.Abstract) != 0)
+				method.Attributes |= MethodAttributes.Abstract;
+
+			if ((treatment & MethodDefinitionTreatment.Private) != 0)
+				method.Attributes = (method.Attributes & ~MethodAttributes.MemberAccessMask) | MethodAttributes.Private;
+
+			if ((treatment & MethodDefinitionTreatment.Public) != 0)
+				method.Attributes = (method.Attributes & ~MethodAttributes.MemberAccessMask) | MethodAttributes.Public;
+
+			if ((treatment & MethodDefinitionTreatment.Runtime) != 0)
+				method.ImplAttributes |= MethodImplAttributes.Runtime;
+
+			if ((treatment & MethodDefinitionTreatment.InternalCall) != 0)
+				method.ImplAttributes |= MethodImplAttributes.InternalCall;
+
+			method.Treatment = treatment;
+		}
+
+		public void RemoveTreatment (MethodDefinition method)
+		{
+			var info = Methods [method.MetadataToken.RID];
+			Methods.Remove (method.MetadataToken.RID);
+
+			method.Treatment = MethodDefinitionTreatment.None;
+
+			method.Attributes = info.Attributes;
+			method.ImplAttributes = info.ImplAttributes;
+			method.Name = info.Name;
+		}
+
+		#endregion
+
+		#region FieldDefinition
+
+		public void Project (FieldDefinition field)
+		{
+			var treatment = FieldDefinitionTreatment.None;
+			var declaring_type = field.DeclaringType;
+
+			if (declaring_type.Module.MetadataKind == MetadataKind.WindowsMetadata && field.IsRuntimeSpecialName && field.Name == "value__") {
+				var base_type = declaring_type.BaseType;
+				if (base_type != null && IsEnum (base_type))
+					treatment = FieldDefinitionTreatment.Public;
+			}
+
+			if (treatment != FieldDefinitionTreatment.None)
+				ApplyTreatment (field, treatment);
+		}
+
+		public void ApplyTreatment (FieldDefinition field, FieldDefinitionTreatment treatment)
+		{
+			Fields [field.MetadataToken.RID] = field.Attributes;
+
+			if (treatment == FieldDefinitionTreatment.Public)
+				field.Attributes = (field.Attributes & ~FieldAttributes.FieldAccessMask) | FieldAttributes.Public;
+
+			field.Treatment = treatment;
+		}
+
+		public void RemoveTreatment (FieldDefinition field)
+		{
+			var attributes = Fields [field.MetadataToken.RID];
+			Fields.Remove (field.MetadataToken.RID);
+
+			field.Treatment = FieldDefinitionTreatment.None;
+
+			field.Attributes = attributes;
+		}
+
+		#endregion
+
+		#region MemberReference
+
+		public void Project (MemberReference member)
+		{
+			bool disposable;
+			if (!ImplementsRedirectedInterface (member, out disposable) || !disposable)
+				return;
+
+			ApplyTreatment (member, MemberReferenceTreatment.Dispose);
+		}
+
+		bool ImplementsRedirectedInterface (MemberReference member, out bool disposable)
+		{
+			disposable = false;
+
+			var declaring_type = member.DeclaringType;
+			TypeReference type;
+			switch (declaring_type.MetadataToken.TokenType) {
+				case TokenType.TypeRef:
+					type = declaring_type;
+					break;
+
+				case TokenType.TypeSpec:
+					if (!declaring_type.IsGenericInstance)
+						return false;
+
+					type = ((TypeSpecification) declaring_type).ElementType;
+					if (type.MetadataType != MetadataType.Class || type.MetadataToken.TokenType != TokenType.TypeRef)
+						return false;
+
+					break;
+
+				default:
+					return false;
+			}
+
+			var treatment = type.Treatment;
+			if (treatment != TypeReferenceTreatment.None)
+				RemoveTreatment(type);
+
+			var found = false;
+
+			ProjectionInfo info;
+			if (Projections.TryGetValue (type.Name, out info) && type.Namespace == info.WinRTNamespace) {
+				disposable = info.Disposable;
+				found = true;
+			}
+
+			if (treatment != TypeReferenceTreatment.None)
+				ApplyTreatment (type, treatment);
+
+			return found;
+		}
+
+		public void ApplyTreatment (MemberReference member, MemberReferenceTreatment treatment)
+		{
+			if (treatment == MemberReferenceTreatment.Dispose)
+				member.Name = "Dispose";
+
+			member.Treatment = treatment;
+		}
+
+		public void RemoveTreatment (MemberReference member)
+		{
+			var treatment = member.Treatment;
+
+			member.Treatment = MemberReferenceTreatment.None;
+
+			if (treatment == MemberReferenceTreatment.Dispose)
+				member.Name = "Close";
+		}
+
+		#endregion
+
+		#region AssemblyReference
+
+		public void AddVirtualReferences (Collection<AssemblyNameReference> references)
+		{
+			var corlib = GetCoreLibrary (references);
+			corlib_version = corlib.Version;
+			corlib.Version = version;
+
+			if (virtual_references == null) {
+				var winrt_references = GetAssemblyReferences (corlib);
+				Interlocked.CompareExchange (ref virtual_references, winrt_references, null);
+			}
+
+			foreach (var reference in virtual_references)
+				references.Add(reference);
+		}
+
+		public void RemoveVirtualReferences (Collection<AssemblyNameReference> references)
+		{
+			var corlib = GetCoreLibrary (references);
+			corlib.Version = corlib_version;
+
+			foreach (var reference in VirtualReferences)
+				references.Remove (reference);
+		}
+
+		static AssemblyNameReference[] GetAssemblyReferences (AssemblyNameReference corlib)
+		{
+			var system_runtime = new AssemblyNameReference ("System.Runtime", version);
+			var system_runtime_interopservices_windowsruntime = new AssemblyNameReference ("System.Runtime.InteropServices.WindowsRuntime", version);
+			var system_objectmodel = new AssemblyNameReference ("System.ObjectModel", version);
+			var system_runtime_windowsruntime = new AssemblyNameReference ("System.Runtime.WindowsRuntime", version);
+			var system_runtime_windowsruntime_ui_xaml = new AssemblyNameReference ("System.Runtime.WindowsRuntime.UI.Xaml", version);
+			var system_numerics_vectors = new AssemblyNameReference ("System.Numerics.Vectors", version);
+
+			if (corlib.HasPublicKey) {
+				system_runtime_windowsruntime.PublicKey =
+				system_runtime_windowsruntime_ui_xaml.PublicKey = corlib.PublicKey;
+
+				system_runtime.PublicKey =
+				system_runtime_interopservices_windowsruntime.PublicKey =
+				system_objectmodel.PublicKey =
+				system_numerics_vectors.PublicKey = contract_pk;
+			}
+			else {
+				system_runtime_windowsruntime.PublicKeyToken =
+				system_runtime_windowsruntime_ui_xaml.PublicKeyToken = corlib.PublicKeyToken;
+
+				system_runtime.PublicKeyToken =
+				system_runtime_interopservices_windowsruntime.PublicKeyToken =
+				system_objectmodel.PublicKeyToken =
+				system_numerics_vectors.PublicKeyToken = contract_pk_token;
+			}
+
+			return new[] {
+				system_runtime,
+				system_runtime_interopservices_windowsruntime,
+				system_objectmodel,
+				system_runtime_windowsruntime,
+				system_runtime_windowsruntime_ui_xaml,
+				system_numerics_vectors,
+			};
+		}
+
+		static AssemblyNameReference GetCoreLibrary (Collection<AssemblyNameReference> references)
+		{
+			foreach (var reference in references)
+				if (reference.Name == "mscorlib")
+					return reference;
+
+			throw new BadImageFormatException ("Missing mscorlib reference in AssemblyRef table.");
+		}
+
+		AssemblyNameReference GetAssemblyReference (string name)
+		{
+			foreach (var assembly in VirtualReferences)
+				if (assembly.Name == name)
+					return assembly;
+
+			throw new Exception ();
+		}
+
+		#endregion
+
+		#region CustomAttribute
+
+		public void Project (ICustomAttributeProvider owner, CustomAttribute attribute)
+		{
+			if (!IsWindowsAttributeUsageAttribute (owner, attribute))
+				return;
+
+			var treatment = CustomAttributeValueTreatment.None;
+			var type = (TypeDefinition)owner;
+
+			if (type.Namespace == "Windows.Foundation.Metadata") {
+				if (type.Name == "VersionAttribute")
+					treatment = CustomAttributeValueTreatment.VersionAttribute;
+				else if (type.Name == "DeprecatedAttribute")
+					treatment = CustomAttributeValueTreatment.DeprecatedAttribute;
+			}
+
+			if (treatment == CustomAttributeValueTreatment.None) {
+				var multiple = HasAttribute (type, "Windows.Foundation.Metadata", "AllowMultipleAttribute");
+				treatment = multiple ? CustomAttributeValueTreatment.AllowMultiple : CustomAttributeValueTreatment.AllowSingle;
+			}
+
+			ApplyTreatment (attribute, treatment);
+		}
+
+		static bool IsWindowsAttributeUsageAttribute (ICustomAttributeProvider owner, CustomAttribute attribute)
+		{
+			if (owner.MetadataToken.TokenType != TokenType.TypeDef)
+				return false;
+
+			var constructor = attribute.Constructor;
+
+			if (constructor.MetadataToken.TokenType != TokenType.MemberRef)
+				return false;
+
+			var declaring_type = constructor.DeclaringType;
+
+			if (declaring_type.MetadataToken.TokenType != TokenType.TypeRef)
+				return false;
+
+			// declaring type is already projected
+			return declaring_type.Name == "AttributeUsageAttribute" && declaring_type.Namespace == /*"Windows.Foundation.Metadata"*/"System";
+		}
+
+		static bool HasAttribute (TypeDefinition type, string @namespace, string name)
+		{
+			foreach (var attribute in type.CustomAttributes) {
+				var attribute_type = attribute.AttributeType;
+				if (attribute_type.Name == name && attribute_type.Namespace == @namespace)
+					return true;
+			}
+			return false;
+		}
+
+		public void ApplyTreatment (CustomAttribute attribute, CustomAttributeValueTreatment treatment)
+		{
+			bool version_or_deprecated;
+			bool multiple;
+
+			switch (treatment) {
+			case CustomAttributeValueTreatment.AllowSingle:
+				version_or_deprecated = false;
+				multiple = false;
+				break;
+
+			case CustomAttributeValueTreatment.AllowMultiple:
+				version_or_deprecated = false;
+				multiple = true;
+				break;
+
+			case CustomAttributeValueTreatment.VersionAttribute:
+			case CustomAttributeValueTreatment.DeprecatedAttribute:
+				version_or_deprecated = true;
+				multiple = true;
+				break;
+
+			default:
+				throw new ArgumentException ();
+			}
+
+			var attribute_targets = (AttributeTargets) attribute.ConstructorArguments [0].Value;
+
+			Attributes [attribute.MetadataToken.RID] = attribute_targets;
+
+			if (version_or_deprecated)
+				attribute_targets |= AttributeTargets.Constructor | AttributeTargets.Property;
+			attribute.ConstructorArguments [0] = new CustomAttributeArgument (attribute.ConstructorArguments [0].Type, attribute_targets);
+
+			attribute.Properties.Add (new CustomAttributeNamedArgument ("AllowMultiple", new CustomAttributeArgument (module.TypeSystem.Boolean, multiple)));
+
+			attribute.treatment = treatment;
+		}
+
+		public void RemoveTreatment (CustomAttribute attribute)
+		{
+			var attribute_targets = Attributes [attribute.MetadataToken.RID];
+			Attributes.Remove (attribute.MetadataToken.RID);
+
+			attribute.treatment = CustomAttributeValueTreatment.None;
+
+			attribute.ConstructorArguments [0] = new CustomAttributeArgument (attribute.ConstructorArguments [0].Type, attribute_targets);
+			attribute.Properties.Clear ();
+		}
+
+		#endregion
+	}
+}


### PR DESCRIPTION
Windows Runtime projections map types from different languages. For example when C++/CX uses Windows::Foundation::Collections::IVector<T> type it appears as System.Collections.Generic.IList<T> to C#.

Could this be resolved with custom MetadataResolver implementation leaving Cecil alone? Kind of, but it's not pretty. For example if you have IClosable.Close method reference it will resolve to IDisposable.Dispose. This confuses a lot of tools which don't expect MethodReference and MethodDefinition to not mach.

Other libraries already support Windows Runtime projections and I tried to emulate one:
https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.WinMD.cs

I have added just a few public APIs:
- ReaderParameters.ApplyWindowsRuntimeProjections: When set to true metadata is projected to CLR. Otherwise it's loaded as is (which is default).
- ModuleDefinition.MetadataKind: Can have three values: Ecma335 - module is not a winmd file or it has been read with runtime projections disabled (default); WindowsMetadata - native winmd file; ManagedWindowsMetadata - managed winmd file.
- MemberReference.IsWindowsRuntimeProjection - true if Windows Runtime projection has been applied to it; false otherwise.

I have also tried to make so that there would be no performance impact for assemblies that don't care about projections. We could #ifdef all this code if needed.

Tests are missing but will be added.

It would be nice to expose underlying type/method/etc for projected type/method/etc.

Projected metadata can't be modified at the moment.

Let me know what you think. I'm happy to change things around (or everything if needed) as I really want to see this feature in Cecil. I've tried using this build with Mono Linker and it works fine with winmd files with very few tweaks.