### PR TITLE
add equality comparing methods for TypeReference

### DIFF
--- a/rocks/Mono.Cecil.Rocks/TypeReferenceRocks.cs
+++ b/rocks/Mono.Cecil.Rocks/TypeReferenceRocks.cs
@@ -18,8 +18,46 @@ namespace Mono.Cecil.Rocks {
 	public
 #endif
 	static class TypeReferenceRocks {
+        public static bool AreSame(TypeReference a, TypeReference b)
+        {
+            var aIsNull = a == null;
+            var bIsNull = b == null;
 
-		public static ArrayType MakeArrayType (this TypeReference self)
+            if (aIsNull)
+            {
+                if (bIsNull)
+                    return true;
+                return false;
+            }
+            if (bIsNull)
+                return false;
+
+            if (a == b)
+                return true;
+
+            if (a.FullName != b.FullName)
+                return false;
+
+            return a.Module.Assembly.FullName == b.Module.Assembly.FullName;
+        }
+
+        public static bool IsSameAs(this TypeReference a, TypeReference b)
+        {
+            if (a == null)
+                throw new NullReferenceException();
+            if (b == null)
+                throw new ArgumentNullException();
+
+            if (a == b)
+                return true;
+
+            if (a.FullName != b.FullName)
+                return false;
+
+            return a.Module.Assembly.FullName == b.Module.Assembly.FullName;
+        }
+
+        public static ArrayType MakeArrayType (this TypeReference self)
 		{
 			return new ArrayType (self);
 		}

--- a/rocks/Mono.Cecil.Rocks/TypeReferenceRocks.cs
+++ b/rocks/Mono.Cecil.Rocks/TypeReferenceRocks.cs
@@ -18,7 +18,7 @@ namespace Mono.Cecil.Rocks {
 	public
 #endif
 	static class TypeReferenceRocks {
-        public static bool AreSame(TypeReference a, TypeReference b)
+        public static bool AreSame(TypeReference a, TypeReference b, bool? useAssemblyFullName = null)
         {
             var aIsNull = a == null;
             var bIsNull = b == null;
@@ -38,10 +38,17 @@ namespace Mono.Cecil.Rocks {
             if (a.FullName != b.FullName)
                 return false;
 
-            return a.Module.Assembly.FullName == b.Module.Assembly.FullName;
+            if (!useAssemblyFullName.HasValue)
+                return true;
+
+            var _a = a.Resolve().Module.Assembly;
+            var _b = b.Resolve().Module.Assembly;
+            if (useAssemblyFullName.Value)
+                return _a.FullName == _b.FullName;
+            return _a.Name.Name == _b.Name.Name;
         }
 
-        public static bool IsSameAs(this TypeReference a, TypeReference b)
+        public static bool IsSameAs(this TypeReference a, TypeReference b, bool? useAssemblyFullName = null)
         {
             if (a == null)
                 throw new NullReferenceException();
@@ -54,7 +61,14 @@ namespace Mono.Cecil.Rocks {
             if (a.FullName != b.FullName)
                 return false;
 
-            return a.Module.Assembly.FullName == b.Module.Assembly.FullName;
+            if (!useAssemblyFullName.HasValue)
+                return true;
+
+            var _a = a.Resolve().Module.Assembly;
+            var _b = b.Resolve().Module.Assembly;
+            if (useAssemblyFullName.Value)
+                return _a.FullName == _b.FullName;
+            return _a.Name.Name == _b.Name.Name;
         }
 
         public static ArrayType MakeArrayType (this TypeReference self)

--- a/rocks/Test/Mono.Cecil.Tests/TypeReferenceRocksTests.cs
+++ b/rocks/Test/Mono.Cecil.Tests/TypeReferenceRocksTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 using Mono.Cecil.Rocks;
 
@@ -8,8 +9,34 @@ namespace Mono.Cecil.Tests {
 
 	[TestFixture]
 	public class TypeReferenceRocksTests {
+        interface IFoo { }
+        interface IBar : IFoo { }
 
-		[Test]
+        [Test]
+        public void AreSame()
+        {
+            var ifoo = typeof(IFoo).ToDefinition();
+            var ibar = typeof(IBar).ToDefinition();
+            var ibarfoo = ibar.Interfaces.Single();
+
+            // for reasons, TypeDefinitions got from ToDefinition() are not same as their "nature" equivalent
+            // this makes testing code involves TypeDefinition relations hard
+            Assert.AreNotEqual(typeof(object).ToDefinition(), typeof(object).ToDefinition());
+            Assert.AreNotEqual(ifoo, ibarfoo);
+
+            Assert.IsTrue(TypeReferenceRocks.AreSame(typeof(object).ToDefinition(), typeof(object).ToDefinition()));
+            Assert.IsTrue(TypeReferenceRocks.AreSame(ibarfoo, ifoo));
+            Assert.IsFalse(TypeReferenceRocks.AreSame(ifoo, null));
+            Assert.IsFalse(TypeReferenceRocks.AreSame(null, ibar));
+
+            Assert.IsTrue(typeof(object).ToDefinition().IsSameAs(typeof(object).ToDefinition()));
+            Assert.IsTrue(ibarfoo.IsSameAs(ifoo));
+            Assert.Throws<ArgumentNullException>(() => ifoo.IsSameAs(null));
+            Assert.Throws<NullReferenceException>(() => ((TypeReference)null).IsSameAs(ibar));
+            Assert.Throws<NullReferenceException>(() => ((TypeReference)null).IsSameAs(null));
+        }
+
+        [Test]
 		public void MakeArrayType ()
 		{
 			var @string = GetTypeReference (typeof (string));


### PR DESCRIPTION
when using ToDefinition() from the test projects, the definition objects are are not same as their "nature" equivalents, this makes testing code involves TypeDefinition relations hard

so i made these methods as a workaround