### PR TITLE
Support reading and writing custom attributes on InterfaceImpl

### DIFF
--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1327,10 +1327,18 @@ namespace Mono.Cecil {
 			var interfaces = type.Interfaces;
 			var type_rid = type.token.RID;
 
-			for (int i = 0; i < interfaces.Count; i++)
-				iface_impl_table.AddRow (new InterfaceImplRow (
+			for (int i = 0; i < interfaces.Count; i++) {
+				var iface_impl = interfaces [i];
+
+				var rid = iface_impl_table.AddRow (new InterfaceImplRow (
 					type_rid,
-					MakeCodedRID (GetTypeToken (interfaces [i]), CodedIndex.TypeDefOrRef)));
+					MakeCodedRID (GetTypeToken (iface_impl.InterfaceType), CodedIndex.TypeDefOrRef)));
+
+				iface_impl.token = new MetadataToken (TokenType.InterfaceImpl, rid);
+
+				if (iface_impl.HasCustomAttributes)
+					AddCustomAttributes (iface_impl);
+			}
 		}
 
 		void AddLayoutInfo (TypeDefinition type)

--- a/Mono.Cecil/MetadataSystem.cs
+++ b/Mono.Cecil/MetadataSystem.cs
@@ -40,7 +40,7 @@ namespace Mono.Cecil {
 
 		internal Dictionary<uint, uint []> NestedTypes;
 		internal Dictionary<uint, uint> ReverseNestedTypes;
-		internal Dictionary<uint, MetadataToken []> Interfaces;
+		internal Dictionary<uint, Row<uint, MetadataToken> []> Interfaces;
 		internal Dictionary<uint, Row<ushort, uint>> ClassLayouts;
 		internal Dictionary<uint, uint> FieldLayouts;
 		internal Dictionary<uint, uint> FieldRVAs;
@@ -239,12 +239,12 @@ namespace Mono.Cecil {
 			ReverseNestedTypes.Remove (type.token.RID);
 		}
 
-		public bool TryGetInterfaceMapping (TypeDefinition type, out MetadataToken [] mapping)
+		public bool TryGetInterfaceMapping (TypeDefinition type, out Row<uint, MetadataToken> [] mapping)
 		{
 			return Interfaces.TryGetValue (type.token.RID, out mapping);
 		}
 
-		public void SetInterfaceMapping (uint type_rid, MetadataToken [] mapping)
+		public void SetInterfaceMapping (uint type_rid, Row<uint, MetadataToken> [] mapping)
 		{
 			Interfaces [type_rid] = mapping;
 		}

--- a/Mono.Cecil/TypeDefinition.cs
+++ b/Mono.Cecil/TypeDefinition.cs
@@ -25,7 +25,7 @@ namespace Mono.Cecil {
 		short packing_size = Mixin.NotResolvedMarker;
 		int class_size = Mixin.NotResolvedMarker;
 
-		Collection<TypeReference> interfaces;
+		InterfaceImplementationCollection interfaces;
 		Collection<TypeDefinition> nested_types;
 		Collection<MethodDefinition> methods;
 		Collection<FieldDefinition> fields;
@@ -105,7 +105,7 @@ namespace Mono.Cecil {
 			}
 		}
 
-		public Collection<TypeReference> Interfaces {
+		public Collection<InterfaceImplementation> Interfaces {
 			get {
 				if (interfaces != null)
 					return interfaces;
@@ -113,7 +113,7 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Module.Read (ref interfaces, this, (type, reader) => reader.ReadInterfaces (type));
 
-				return interfaces = new Collection<TypeReference> ();
+				return interfaces = new InterfaceImplementationCollection (this);
 			}
 		}
 
@@ -458,6 +458,89 @@ namespace Mono.Cecil {
 		public override TypeDefinition Resolve ()
 		{
 			return this;
+		}
+	}
+
+	public class InterfaceImplementation : ICustomAttributeProvider
+	{
+		internal TypeDefinition type;
+		internal MetadataToken token;
+
+		TypeReference interface_type;
+		Collection<CustomAttribute> custom_attributes;
+
+		public TypeReference InterfaceType {
+			get { return interface_type; }
+			set { interface_type = value; }
+		}
+
+		public bool HasCustomAttributes {
+			get {
+				if (custom_attributes != null)
+					return custom_attributes.Count > 0;
+
+				return this.GetHasCustomAttributes (type.Module);
+			}
+		}
+
+		public Collection<CustomAttribute> CustomAttributes {
+			get { return custom_attributes ?? (this.GetCustomAttributes (ref custom_attributes, type.Module)); }
+		}
+
+		public MetadataToken MetadataToken {
+			get { return token; }
+			set { token = value; }
+		}
+
+		internal InterfaceImplementation (TypeReference interfaceType, MetadataToken token)
+		{
+			this.interface_type = interfaceType;
+			this.token = token;
+		}
+
+		public InterfaceImplementation (TypeReference interfaceType)
+		{
+			if (interfaceType == null)
+				throw new ArgumentNullException ("interfaceType");
+
+			this.interface_type = interfaceType;
+			this.token = new MetadataToken (TokenType.InterfaceImpl);
+		}
+	}
+
+	class InterfaceImplementationCollection : Collection<InterfaceImplementation>
+	{
+		readonly TypeDefinition type;
+
+		internal InterfaceImplementationCollection (TypeDefinition type)
+		{
+			this.type = type;
+		}
+
+		internal InterfaceImplementationCollection (TypeDefinition type, int length)
+			: base (length)
+		{
+			this.type = type;
+		}
+
+		protected override void OnAdd (InterfaceImplementation item, int index)
+		{
+			item.type = type;
+		}
+
+		protected override void OnInsert (InterfaceImplementation item, int index)
+		{
+			item.type = type;
+		}
+
+		protected override void OnSet (InterfaceImplementation item, int index)
+		{
+			item.type = type;
+		}
+
+		protected override void OnRemove (InterfaceImplementation item, int index)
+		{
+			item.type = null;
 		}
 	}
 

--- a/Mono.Cecil/TypeDefinition.cs
+++ b/Mono.Cecil/TypeDefinition.cs
@@ -479,12 +479,20 @@ namespace Mono.Cecil {
 				if (custom_attributes != null)
 					return custom_attributes.Count > 0;
 
+				if (type == null)
+					return false;
+
 				return this.GetHasCustomAttributes (type.Module);
 			}
 		}
 
 		public Collection<CustomAttribute> CustomAttributes {
-			get { return custom_attributes ?? (this.GetCustomAttributes (ref custom_attributes, type.Module)); }
+			get {
+				if (type == null)
+					return custom_attributes = new Collection<CustomAttribute> ();
+
+				return custom_attributes ?? (this.GetCustomAttributes (ref custom_attributes, type.Module));
+			}
 		}
 
 		public MetadataToken MetadataToken {

--- a/Test/Mono.Cecil.Tests/CustomAttributesTests.cs
+++ b/Test/Mono.Cecil.Tests/CustomAttributesTests.cs
@@ -33,7 +33,7 @@ namespace Mono.Cecil.Tests {
 
 				AssertArgument ("bar", attribute.ConstructorArguments [0]);
 			});
-        }
+		}
 
 		[Test]
 		public void NullString ()
@@ -409,6 +409,21 @@ namespace Mono.Cecil.Tests {
 				Assert.AreEqual (1, attribute.CustomAttributes.Count);
 				Assert.AreEqual (0, attribute.CustomAttributes [0].ConstructorArguments.Count);
 			}, verify: !Platform.OnMono);
+		}
+
+		[Test]
+		public void InterfaceImplementation ()
+		{
+			IgnoreOnMono();
+
+			TestIL ("ca-iface-impl.il", module => {
+				var type = module.GetType ("FooType");
+				var iface = type.Interfaces.Single (i => i.InterfaceType.FullName == "IFoo");
+				Assert.IsTrue (iface.HasCustomAttributes);
+				var attributes = iface.CustomAttributes;
+				Assert.AreEqual (1, attributes.Count);
+				Assert.AreEqual ("FooAttribute", attributes [0].AttributeType.FullName);
+			});
 		}
 
 		[Test]

--- a/Test/Mono.Cecil.Tests/TypeTests.cs
+++ b/Test/Mono.Cecil.Tests/TypeTests.cs
@@ -44,8 +44,8 @@ namespace Mono.Cecil.Tests {
 				Assert.AreEqual (2, interfaces.Count);
 
 				// Mono's ilasm and .NET's are ordering interfaces differently
-				Assert.IsNotNull (interfaces.Single (i => i.FullName == "IBar"));
-				Assert.IsNotNull (interfaces.Single (i => i.FullName == "IFoo"));
+				Assert.IsNotNull (interfaces.Single (i => i.InterfaceType.FullName == "IBar"));
+				Assert.IsNotNull (interfaces.Single (i => i.InterfaceType.FullName == "IFoo"));
 			});
 		}
 
@@ -181,7 +181,7 @@ namespace Mono.Cecil.Tests {
 				var type = module.GetType ("Program");
 				var iface = type.Interfaces [0];
 
-				var instance = (GenericInstanceType) iface;
+				var instance = (GenericInstanceType) iface.InterfaceType;
 				var owner = instance.ElementType;
 
 				Assert.AreEqual (1, instance.GenericArguments.Count);

--- a/Test/Resources/il/ca-iface-impl.il
+++ b/Test/Resources/il/ca-iface-impl.il
@@ -1,0 +1,35 @@
+.assembly extern mscorlib {}
+
+.assembly CA {}
+
+.module CA.dll
+
+.class public auto ansi beforefieldinit FooAttribute
+	extends [mscorlib]System.Attribute
+{
+	.method public hidebysig specialname rtspecialname instance void .ctor ()
+	{
+		ldarg.0
+		call instance void [mscorlib]System.Attribute::.ctor ()
+		ret
+	}
+}
+
+.class interface public auto ansi abstract IFoo
+{
+}
+
+.class public auto ansi beforefieldinit FooType
+	extends [mscorlib]System.Object
+	implements IFoo
+{
+	.interfaceimpl type IFoo
+	.custom instance void FooAttribute::.ctor ()
+
+	.method public hidebysig specialname rtspecialname instance void .ctor ()
+	{
+		ldarg.0
+		call instance void [mscorlib]System.Object::.ctor ()
+		ret
+	}
+}


### PR DESCRIPTION
WinRT uses custom attributes in winmd files that are declared for InterfaceImpl rows.
This is a breaking API change that we could not represent before.
There's other places that we do not support reading and writing custom attributes on,
like generic parameter constraints. Let's fix it when we need it.