### PR TITLE
Validate PDB magic and ImageDebugDirectory type and version

### DIFF
--- a/symbols/pdb/Mono.Cecil.Pdb/PdbReader.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/PdbReader.cs
@@ -41,6 +41,11 @@ namespace Mono.Cecil.Pdb {
 
 		public bool ProcessDebugHeader (ImageDebugDirectory directory, byte [] header)
 		{
+			if (directory.Type != 2) //IMAGE_DEBUG_TYPE_CODEVIEW
+				return false;
+			if (directory.MajorVersion != 0 || directory.MinorVersion != 0)
+				return false;
+
 			if (header.Length < 24)
 				return false;
 


### PR DESCRIPTION
Presently PdbReader does not validate that it is actually opening a traditional PDB. If a portable PDB is opened, the Portable PDB file is blindly assumed to be a regular PDB and parsing eventually fails when a huge array is attempted to be allocated:
```
System.OutOfMemoryException: Array dimensions exceeded supported range.
   at Microsoft.Cci.Pdb.MsfDirectory..ctor(PdbReader reader, PdbFileHeader head, BitAccess bits)
   at Microsoft.Cci.Pdb.PdbFile.LoadFunctions(Stream read, Dictionary`2& tokenToSourceMapping, String& sourceServerData, Int32& age, Guid& guid)
   at Mono.Cecil.Pdb.PdbReader.PopulateFunctions()
   at Mono.Cecil.Pdb.PdbReader.ProcessDebugHeader(ImageDebugDirectory directory, Byte[] header)
   at Mono.Cecil.ModuleDefinition.ProcessDebugHeader()
   at ICSharpCode.ILSpy.LoadedAssembly.LoadSymbols(ModuleDefinition module)
```
This pull request validates both the ImageDebugDirectory in the PE file and the magic at the beginning of a PDB file. This change is motivated by icsharpcode/ILSpy#723, which expects `InvalidOperationException` when the file is invalid, not `OutOfMemoryException`.