### PR TITLE
Use debug symbol files based on files availability instead of hardcoded values

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -99,7 +99,7 @@ namespace Mono.Cecil {
 
 #if !PCL
 			if (symbol_reader_provider == null && parameters.ReadSymbols)
-				symbol_reader_provider = SymbolProvider.GetPlatformReaderProvider ();
+				symbol_reader_provider = SymbolProvider.GetReaderProvider (module);
 #endif
 
 			if (symbol_reader_provider != null) {

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -90,7 +90,7 @@ namespace Mono.Cecil {
 			var symbol_writer_provider = parameters.SymbolWriterProvider;
 #if !PCL && !NET_CORE
 			if (symbol_writer_provider == null && parameters.WriteSymbols)
-				symbol_writer_provider = SymbolProvider.GetPlatformWriterProvider ();
+				symbol_writer_provider = SymbolProvider.GetWriterProvider (module.symbol_reader);
 #endif
 			var symbol_writer = GetSymbolWriter (module, fq_name, symbol_writer_provider, parameters);
 

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -1052,7 +1052,7 @@ namespace Mono.Cecil {
 			if (string.IsNullOrEmpty (file_name))
 				throw new InvalidOperationException ();
 
-			var provider = SymbolProvider.GetPlatformReaderProvider ();
+			var provider = SymbolProvider.GetReaderProvider (this);
 			if (provider == null)
 				throw new InvalidOperationException ();
 


### PR DESCRIPTION
Enables implicit (p)pdb support on mono
