### PR TITLE
Fixes crash for methods with no debug information

### DIFF
--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -2405,6 +2405,9 @@ namespace Mono.Cecil {
 
 		uint AddImportScope (ImportDebugInformation import)
 		{
+			if (import == null)
+				return 0;
+
 			uint parent = 0;
 			if (import.Parent != null)
 				parent = AddImportScope (import.Parent);


### PR DESCRIPTION
ScopeDebugInformation is set conditionally at https://github.com/jbevain/cecil/blob/e5ab266abb3a65b6948bc767c062ec04ff4284b7/Mono.Cecil/AssemblyReader.cs#L2935

but it's used unconditionally at https://github.com/jbevain/cecil/blob/e5ab266abb3a65b6948bc767c062ec04ff4284b7/Mono.Cecil/AssemblyWriter.cs#L2254 causing NRE for methods with no scope information.