### PR TITLE
Changed PdbReaderProvider.IsPortablePdb so that it uses FileShare.Read

### DIFF
--- a/symbols/pdb/Mono.Cecil.Pdb/PdbHelper.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/PdbHelper.cs
@@ -59,7 +59,7 @@ namespace Mono.Cecil.Pdb {
 
 		static bool IsPortablePdb (string fileName)
 		{
-			using (var file = new FileStream (fileName, FileMode.Open, FileAccess.Read, FileShare.None))
+			using (var file = new FileStream (fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
 				return IsPortablePdb (file);
 		}
 


### PR DESCRIPTION
I've updated [Smocks](https://github.com/vanderkleij/Smocks) to use Cecil 0.10.0-beta1-v2. Many of its unit tests then broke because Cecil's `PdbReaderProvider` was trying to open PDB files that were already in use by another process (probably Visual Studio) with exclusive access (FileShare.None).

Since we're only reading from the PDB, I don't think exclusive access is required and we can just allow others to read from the PDB simultaneously (FileShare.Read). 