### PR TITLE
handle broken mdb's better

### DIFF
--- a/Mono.Cecil.Cil/CodeReader.cs
+++ b/Mono.Cecil.Cil/CodeReader.cs
@@ -159,17 +159,20 @@ namespace Mono.Cecil.Cil {
 
 		void ReadScope (ScopeDebugInformation scope)
 		{
-			scope.Start = new InstructionOffset (GetInstruction (scope.Start.Offset));
+			var start_instruction = GetInstruction (scope.Start.Offset);
+			if (start_instruction != null)
+				scope.Start = new InstructionOffset (start_instruction);
 
 			var end_instruction = GetInstruction (scope.End.Offset);
-			scope.End = end_instruction == null
-				? new InstructionOffset ()
-				: new InstructionOffset (end_instruction);
+			if (end_instruction != null)
+				scope.End = new InstructionOffset (end_instruction);
 
 			if (!scope.variables.IsNullOrEmpty ()) {
 				for (int i = 0; i < scope.variables.Count; i++) {
-					var variable = scope.variables [i];
-					variable.index = new VariableIndex (GetVariable (variable.Index));
+					var variable_info = scope.variables [i];
+					var variable = GetVariable (variable_info.Index);
+					if (variable != null)
+						variable_info.index = new VariableIndex (variable);
 				}
 			}
 


### PR DESCRIPTION
 - don't crash when reading broken mdb file, with wrong scope and
   variable info

 - fixes XA bug #46509

 - the fix itself leaves the InstructionOffset's untouched if we
   cannot get the right instruction, so that it can be later saved
   unmodified. similar with the variables.

   if we set them to new InstructionOffset () (as we did before with
   scope.End), we would be in trouble when writting the assembly and
   getting:

      Unhandled Exception:
      System.NotSupportedException: Specified method is not supported.
        at Mono.Cecil.Cil.InstructionOffset.get_Offset () [0x00044] in <8f01998b99f54be3b524fda5957c24a4>:0
        at Mono.Cecil.Mdb.MdbWriter.WriteScope (Mono.Cecil.Cil.ScopeDebugInformation scope, Mono.Cecil.Cil.MethodDebugInformation info) [0x0000d] in <295a3dc9e3bb487a8ed0f8a382443202>:0
        at Mono.Cecil.Mdb.MdbWriter.WriteScopes (Mono.Collections.Generic.Collection`1[T] scopes, Mono.Cecil.Cil.MethodDebugInformation info) [0x00010] in <295a3dc9e3bb487a8ed0f8a382443202>:0
        at Mono.Cecil.Mdb.MdbWriter.WriteScope (Mono.Cecil.Cil.ScopeDebugInformation scope, Mono.Cecil.Cil.MethodDebugInformation info) [0x00034] in <295a3dc9e3bb487a8ed0f8a382443202>:0
        at Mono.Cecil.Mdb.MdbWriter.WriteScopes (Mono.Collections.Generic.Collection`1[T] scopes, Mono.Cecil.Cil.MethodDebugInformation info) [0x00010] in <295a3dc9e3bb487a8ed0f8a382443202>:0
        at Mono.Cecil.Mdb.MdbWriter.WriteRootScope (Mono.Cecil.Cil.ScopeDebugInformation scope, Mono.Cecil.Cil.MethodDebugInformation info) [0x0001a] in <295a3dc9e3bb487a8ed0f8a382443202>:0
        at Mono.Cecil.Mdb.MdbWriter.Write (Mono.Cecil.Cil.MethodDebugInformation info) [0x000c4] in <295a3dc9e3bb487a8ed0f8a382443202>:0

 - example dump of broken mdb:

    <file id="10" name="C:\Users\rodo\Desktop\NineOldAndroids\NineOldAndroids\obj\Release\generated\src\Xamarin.NineOldAndroids.Animations.AnimatorListenerAdapter.cs" checksum="2f89fe427745a3
9ae0626f6f28b382d5" />

    <method token="0x6000143" signature="System.Void Xamarin.NineOldAndroids.Animations.Animator/IAnimatorListenerInvoker::OnAnimationStart(Xamarin.NineOldAndroids.Animations.Animator)">
      <sequencepoints>
        <entry il="0x0" row="78" col="4" file_ref="10" />
        <entry il="0x11" row="79" col="5" file_ref="10" />
        <entry il="0x2a" row="81" col="5" file_ref="10" />
        <entry il="0x36" row="82" col="5" file_ref="10" />
        <entry il="0x42" row="84" col="5" file_ref="10" />
        <entry il="0x55" row="85" col="6" file_ref="10" />
        <entry il="0x67" row="87" col="6" file_ref="10" />
        <entry il="0x8e" row="90" col="3" file_ref="10" />
      </sequencepoints>
      <locals>
        <entry name="__args" il_index="0" scope_ref="2" />
      </locals>
      <scopes>
        <entry index="0" start="0x0" end="0x8f" />
        <entry index="1" start="0x2a" end="0x8e" />
      </scopes>
    </method>

while the correct mdb look like this:

    <file id="2" name="Xamarin.NineOldAndroids.Animations.Animator.cs" checksum="a3a6dd06d29873ec238f66444baa7264" />

    <method token="0x6000059" signature="System.Void Xamarin.NineOldAndroids.Animations.Animator/IAnimatorListenerInvoker::OnAnimationStart(Xamarin.NineOldAndroids.Animations.Animator)">
      <sequencepoints>
        <entry il="0x0" row="177" col="5" file_ref="2" />
        <entry il="0x15" row="178" col="6" file_ref="2" />
        <entry il="0x30" row="179" col="5" file_ref="2" />
        <entry il="0x3b" row="180" col="5" file_ref="2" />
        <entry il="0x47" row="181" col="5" file_ref="2" />
      </sequencepoints>
      <locals>
        <entry name="__args" il_index="0" scope_ref="0" />
      </locals>
      <scopes />
    </method>

note that the file_ref, scopes and locals were wrong. the source code
for the method was the same.