### PR TITLE
Optimize ldc.i8

### DIFF
--- a/rocks/Mono.Cecil.Rocks/MethodBodyRocks.cs
+++ b/rocks/Mono.Cecil.Rocks/MethodBodyRocks.cs
@@ -174,6 +174,15 @@ namespace Mono.Cecil.Rocks {
 			instruction.Operand = null;
 		}
 
+		public static void Optimize(this MethodBody self)
+		{
+			if (self == null)
+				throw new ArgumentNullException("self");
+
+			OptimizeLongs(self);
+			OptimizeMacros(self);
+		}
+
 		static void OptimizeLongs(this MethodBody self)
 		{
 			var method = self.Method;
@@ -193,8 +202,6 @@ namespace Mono.Cecil.Rocks {
 		{
 			if (self == null)
 				throw new ArgumentNullException ("self");
-
-			OptimizeLongs(self);
 
 			var method = self.Method;
 

--- a/rocks/Mono.Cecil.Rocks/MethodBodyRocks.cs
+++ b/rocks/Mono.Cecil.Rocks/MethodBodyRocks.cs
@@ -174,27 +174,26 @@ namespace Mono.Cecil.Rocks {
 			instruction.Operand = null;
 		}
 
-		public static void Optimize(this MethodBody self)
+		public static void Optimize (this MethodBody self)
 		{
 			if (self == null)
-				throw new ArgumentNullException("self");
+				throw new ArgumentNullException ("self");
 
-			OptimizeLongs(self);
-			OptimizeMacros(self);
+			OptimizeLongs (self);
+			OptimizeMacros (self);
 		}
 
-		static void OptimizeLongs(this MethodBody self)
+		static void OptimizeLongs (this MethodBody self)
 		{
-			var method = self.Method;
 			for (var i = 0; i < self.Instructions.Count; i++) {
-				var instruction = self.Instructions[i];
+				var instruction = self.Instructions [i];
 				if (instruction.OpCode.Code != Code.Ldc_I8)
 					continue;
 				var l = (long)instruction.Operand;
 				if (l >= uint.MaxValue)
 					continue;
-				ExpandMacro(instruction, OpCodes.Ldc_I4, (uint)l);
-				self.Instructions.Insert(++i, Instruction.Create(OpCodes.Conv_I8));
+				ExpandMacro (instruction, OpCodes.Ldc_I4, (uint)l);
+				self.Instructions.Insert (++i, Instruction.Create (OpCodes.Conv_I8));
 			}
 		}
 


### PR DESCRIPTION
Optimize Ldc.I8 calls when the value fits an int.

This saves 3 to 7 bytes of code.

e.g., this IL (9 bytes):
```
IL_0047:  ldc.i8 0x0
IL_0050:  ....
```
is optimized into this (2 bytes)
```
IL_0032:  ldc.i4.0 
IL_0033:  conv.i8 
IL_0034:  ....
```

This (9B):
```
IL_00b9:  ldc.i8 0x7f
IL_00c2:  .... 
```
into (3B):
```
IL_00a6:  ldc.i4.s 0x7f
IL_00a8:  conv.i8 
IL_00a9:  ....
```

And this (9B):
```
IL_0059:  ldc.i8 0x7fffffff
IL_0062:  ....
```
into (6B)
```
IL_003a:  ldc.i4 2147483647
IL_003f:  conv.i8 
IL_0040:  .... 
```