### PR TITLE
Fix ImageDebugDirectory.MinorVersion in portable pdb writer

### DIFF
--- a/Mono.Cecil.Cil/PortablePdb.cs
+++ b/Mono.Cecil.Cil/PortablePdb.cs
@@ -204,7 +204,7 @@ namespace Mono.Cecil.Cil {
 
 			directory = new ImageDebugDirectory () {
 				MajorVersion = 256,
-				MinorVersion = 20577,
+				MinorVersion = 20557,
 				Type = 2,
 			};
 


### PR DESCRIPTION
The minor version is wrong, it should be 20557 (0x504d) according to the spec: https://github.com/dotnet/corefx/blob/fd15ab1de03a4431e0ead9ff10e1bf53e2ae4bb7/src/System.Reflection.Metadata/specs/PE-COFF.md#codeview-debug-directory-entry-type-2

Fixes https://github.com/jbevain/cecil/issues/309