### PR TITLE
Fix BaseAssemblyResolver.SearchDirectory.

### DIFF
--- a/Mono.Cecil/BaseAssemblyResolver.cs
+++ b/Mono.Cecil/BaseAssemblyResolver.cs
@@ -158,8 +158,13 @@ namespace Mono.Cecil {
 			foreach (var directory in directories) {
 				foreach (var extension in extensions) {
 					string file = Path.Combine (directory, name.Name + extension);
-					if (File.Exists (file))
+					if (!File.Exists (file))
+						continue;
+					try {
 						return GetAssembly (file, parameters);
+					} catch (System.BadImageFormatException) {
+						continue;
+					}
 				}
 			}
 


### PR DESCRIPTION
Fix BaseAssemblyResolver.SearchDirectory to try both .exe and .dll when searching for an assembly.
This fixes a scenario when there is a native Foo.exe and a managed Foo.dll in the search directories.
