### PR TITLE
Fixed possible NullReferenceException

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -656,6 +656,9 @@ namespace Mono.Cecil {
 		{
 			var rva = image.Resources.VirtualAddress;
 			var section = image.GetSectionAtVirtualAddress (rva);
+			if (section == null)
+				return null;
+
 			var position = (rva - section.VirtualAddress) + offset;
 			var buffer = section.Data;
 


### PR DESCRIPTION
I have some assemblies without a `ResourceTable` entry, which produce a `System.NullReferenceException` ~~and no types are listed in the ILSpy TreeView~~. I've added a null check to fix this.