### PR TITLE
Optimize StringHeap size.

### DIFF
--- a/Mono.Cecil.Cil/PortablePdb.cs
+++ b/Mono.Cecil.Cil/PortablePdb.cs
@@ -249,6 +249,7 @@ namespace Mono.Cecil.Cil {
 				return;
 
 			WritePdbHeap ();
+
 			WriteTableHeap ();
 
 			writer.BuildMetadataTextMap ();
@@ -291,6 +292,10 @@ namespace Mono.Cecil.Cil {
 
 		void WriteTableHeap ()
 		{
+			if (module_metadata.string_heap != pdb_metadata.string_heap) {
+				pdb_metadata.table_heap.string_offsets = pdb_metadata.string_heap.WriteStrings ();
+			}
+
 			pdb_metadata.table_heap.WriteTableHeap ();
 		}
 	}

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1007,6 +1007,8 @@ namespace Mono.Cecil {
 		{
 			BuildModule ();
 
+			table_heap.string_offsets = string_heap.WriteStrings ();
+
 			table_heap.WriteTableHeap ();
 		}
 


### PR DESCRIPTION
This change reduces the size of StringHeap by re-using string suffixes wherever possible.
Before this change, if metadata strings `foo` and `foobar` were needed, both would be emitted.
With this change, only `foobar` will be emitted and its suffix will be used for `bar`.

Most of the implementation is taken from Roslyn: https://github.com/dotnet/roslyn/blob/614299ff83da9959fa07131c6d0ffbc58873b6ae/src/Compilers/Core/Portable/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs#L287

StringHeapBuffer.GetStringIndex doesn't eagerly write bytes to the buffer; instead, it just assigns each string
an index and keeps the map from strings to indexes. After AssemblyWriter.BuildModule completes and all strings have been
collected, a new method WriteStrings implements the optimization that reuses string suffixes. A map of string indexes to buffer
offsets is returned. That map is used in Metadata.WriteString to emit correct string offsets.