### PR TITLE
Throw detailed exception when debug symbols provider is not found

### DIFF
--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -729,9 +729,10 @@ namespace Mono.Cecil.Cil {
 			if (kind == SymbolKind.PortablePdb)
 				return new PortablePdbReaderProvider ();
 
-			var type = GetSymbolType (kind, GetSymbolTypeName (kind, "ReaderProvider"));
+			var providerName = GetSymbolTypeName (kind, "ReaderProvider");
+			var type = GetSymbolType (kind, providerName);
 			if (type == null)
-				return null;
+				throw new TypeLoadException ("Could not find symbol provider type " + providerName);
 
 			return (ISymbolReaderProvider) Activator.CreateInstance (type);
 		}


### PR DESCRIPTION
instead of NullReferenceException in Mono.Cecil.Cil.SymbolProvider.GetReaderProvider