### PR TITLE
enable build using new cli tools

### DIFF
--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Reflection;
 using SR = System.Reflection;
 
 using Mono.Collections.Generic;
@@ -739,7 +740,11 @@ namespace Mono.Cecil.Cil {
 		static string GetSymbolTypeName (SymbolKind kind, string name)
 		{
 			var ns = GetSymbolNamespace (kind);
+#if !NET_CORE
 			return typeof (SymbolProvider).Assembly.GetName ().Name + "." + ns + "." + kind + name;
+#else
+			return typeof (SymbolProvider).GetTypeInfo().Assembly.GetName ().Name + "." + ns + "." + kind + name;
+#endif
 		}
 
 		static string GetSymbolNamespace (SymbolKind kind)

--- a/Mono.Cecil.new.csproj
+++ b/Mono.Cecil.new.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Mono.Cecil</AssemblyName>
+    <Version>0.10.0.0-beta1</Version>
+    <Copyright>Copyright © 2008 - 2015 Jb Evain</Copyright>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <OutputType>library</OutputType>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard1.3'">$(DefineConstants);NET_CORE</DefineConstants>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Mono\*.cs" />
+    <Compile Include="Mono.Cecil\*.cs" />
+    <Compile Include="Mono.Cecil.Cil\*.cs" />
+    <Compile Include="Mono.Cecil.Metadata\*.cs" />
+    <Compile Include="Mono.Cecil.PE\*.cs" />
+    <Compile Include="Mono.Collections.Generic\*.cs" />
+    <Compile Include="Mono.Security.Cryptography\*.cs" />
+    <Compile Include="System.Security.Cryptography\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/Mono.Cecil/AssemblyInfo.cs
+++ b/Mono.Cecil/AssemblyInfo.cs
@@ -12,7 +12,9 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+#if !NET_CORE
 [assembly: AssemblyTitle ("Mono.Cecil")]
+#endif
 
 #if !PCL && !NET_CORE
 [assembly: Guid ("fd225bb4-fa53-44b2-a6db-85f5e48dcb54")]

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -1061,7 +1061,6 @@ namespace Mono.Cecil {
 			ReadSymbols (provider.GetSymbolReader (this, file_name));
 		}
 #endif
-
 		public void ReadSymbols (ISymbolReader reader)
 		{
 			if (reader == null)

--- a/rocks/Mono.Cecil.Rocks.new.csproj
+++ b/rocks/Mono.Cecil.Rocks.new.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Mono.Cecil.Rocks</AssemblyName>
+    <TargetFramework>netstandard1.3</TargetFramework>
+    <DefineConstants>$(DefineConstants);INSIDE_ROCKS</DefineConstants>
+    <OutputType>library</OutputType>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.3'">
+    <Compile Include="..\ProjectInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Mono.Cecil.Rocks\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <Compile Remove="Mono.Cecil.Rocks\SecurityDeclarationRocks.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mono.Cecil.new.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/rocks/Mono.Cecil.Rocks/AssemblyInfo.cs
+++ b/rocks/Mono.Cecil.Rocks/AssemblyInfo.cs
@@ -11,6 +11,8 @@
 using System;
 using System.Reflection;
 
+#if !NET_CORE
 [assembly: AssemblyTitle ("Mono.Cecil.Rocks")]
+#endif
 
 [assembly: CLSCompliant (false)]


### PR DESCRIPTION
@erozenfeld @jbevain 

This change adds new .csproj files designed for consumption using the
new dotnet cli tools. This enables one to build cecil using the commands
```
dotnet restore Mono.Cecil.new.csproj
dotnet build Mono.Cecil.new.csproj
```

The new .csproj file defines the build constant NET_CORE when cecil is
being built against netstandard (the new file also supports building
for the desktop framework).

Because the new .csproj is used to specify some assembly metadata that
was previously in .cs files, the redundant information has been put
under an #ifdef in the .cs files.

Finally, one line has been changed to use GetTypeInfo, a reflection
API in netstandard1.3 but not in net45.