### PR TITLE
Preserve PE timestamps.

### DIFF
--- a/Mono.Cecil.PE/Image.cs
+++ b/Mono.Cecil.PE/Image.cs
@@ -33,6 +33,7 @@ namespace Mono.Cecil.PE {
 		public Section MetadataSection;
 
 		public uint EntryPointToken;
+		public uint TimeStamp;
 		public ModuleAttributes Attributes;
 
 		public DataDirectory Debug;

--- a/Mono.Cecil.PE/ImageReader.cs
+++ b/Mono.Cecil.PE/ImageReader.cs
@@ -70,10 +70,11 @@ namespace Mono.Cecil.PE {
 			ushort sections = ReadUInt16 ();
 
 			// TimeDateStamp		4
+			image.TimeStamp = ReadUInt32 ();
 			// PointerToSymbolTable	4
 			// NumberOfSymbols		4
 			// OptionalHeaderSize	2
-			Advance (14);
+			Advance (10);
 
 			// Characteristics		2
 			ushort characteristics = ReadUInt16 ();

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -866,7 +866,7 @@ namespace Mono.Cecil {
 			this.module = module;
 			this.text_map = CreateTextMap ();
 			this.fq_name = fq_name;
-			this.time_stamp = (uint) DateTime.UtcNow.Subtract (new DateTime (1970, 1, 1)).TotalSeconds;
+			this.time_stamp = module.timestamp;
 			this.symbol_writer_provider = symbol_writer_provider;
 
 			if (symbol_writer == null && module.HasImage && module.Image.HasDebugTables ()) {

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -260,6 +260,7 @@ namespace Mono.Cecil {
 		ModuleAttributes attributes;
 		ModuleCharacteristics characteristics;
 		Guid mvid;
+		internal uint timestamp;
 
 		internal AssemblyDefinition assembly;
 		MethodDefinition entry_point;
@@ -568,6 +569,7 @@ namespace Mono.Cecil {
 			this.attributes = image.Attributes;
 			this.characteristics = image.Characteristics;
 			this.file_name = image.FileName;
+			this.timestamp = image.TimeStamp;
 
 			this.reader = new MetadataReader (this);
 		}


### PR DESCRIPTION
Read PE timestamps from PE files, and write the same value back.

This makes Cecil's output deterministic when used with C# or VB's
/deterministic compiler option.