### PR TITLE
Support ReadSymbols() on .NET Core

### DIFF
--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -1069,7 +1069,7 @@ namespace Mono.Cecil {
 
 #endif
 
-#if !PCL && !NET_CORE
+#if !PCL
 		public void ReadSymbols ()
 		{
 			if (string.IsNullOrEmpty (file_name))


### PR DESCRIPTION
It looks like [322](https://github.com/jbevain/cecil/pull/322) changed ReadSymbols() to use DefaultSymbolReaderProvider, so we should be able to use ReadSymbols() on .NET Core now.
