### PR TITLE
Make AssemblyResolutionException available on core

### DIFF
--- a/Mono.Cecil/BaseAssemblyResolver.cs
+++ b/Mono.Cecil/BaseAssemblyResolver.cs
@@ -8,7 +8,7 @@
 // Licensed under the MIT/X11 license.
 //
 
-#if !PCL && !NET_CORE
+#if !PCL
 
 using System;
 using System.Collections.Generic;
@@ -35,7 +35,9 @@ namespace Mono.Cecil {
 		}
 	}
 
+#if !NET_CORE
 	[Serializable]
+#endif
 	public sealed class AssemblyResolutionException : FileNotFoundException {
 
 		readonly AssemblyNameReference reference;
@@ -50,14 +52,17 @@ namespace Mono.Cecil {
 			this.reference = reference;
 		}
 
+#if !NET_CORE
 		AssemblyResolutionException (
 			System.Runtime.Serialization.SerializationInfo info,
 			System.Runtime.Serialization.StreamingContext context)
 			: base (info, context)
 		{
 		}
+#endif
 	}
 
+#if !NET_CORE
 	public abstract class BaseAssemblyResolver : IAssemblyResolver {
 
 		static readonly bool on_mono = Type.GetType ("Mono.Runtime") != null;
@@ -341,6 +346,7 @@ namespace Mono.Cecil {
 		{
 		}
 	}
+#endif
 }
 
 #endif


### PR DESCRIPTION
We'd like to use this from the linker's assembly resolver.