### PR TITLE
Fixed DocCommentId cast for `OptionalModifier`

### DIFF
--- a/rocks/Mono.Cecil.Rocks/DocCommentId.cs
+++ b/rocks/Mono.Cecil.Rocks/DocCommentId.cs
@@ -111,7 +111,7 @@ namespace Mono.Cecil.Rocks {
 					id.Append (((GenericParameter) type).Position);
 					break;
 				case MetadataType.OptionalModifier:
-					WriteModiferTypeSignature ((RequiredModifierType) type, '!');
+					WriteModiferTypeSignature ((OptionalModifierType) type, '!');
 					break;
 				case MetadataType.RequiredModifier:
 					WriteModiferTypeSignature ((RequiredModifierType) type, '|');


### PR DESCRIPTION
An example ... for the following method in the `System.Printing.dll` assembly that ships with .net 4.6.2:

`System.ValueType modopt(System.DateTime) modopt(System.Runtime.CompilerServices.IsBoxed) System.Printing.IndexedProperties.PrintDateTimeProperty::op_Implicit(System.Printing.IndexedProperties.PrintDateTimeProperty)`

The return type's `MetadataType` is `OptionalModifier` ... and this code was original trying to cast it to `RequiredModifierType`.