### PR TITLE
Fix SequencePoint.IsHidden comparing start_column, not end_line

### DIFF
--- a/Mono.Cecil.Cil/SequencePoint.cs
+++ b/Mono.Cecil.Cil/SequencePoint.cs
@@ -47,7 +47,7 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public bool IsHidden {
-			get { return start_line == 0xfeefee && start_line == start_column; }
+			get { return start_line == 0xfeefee && start_line == end_line; }
 		}
 
 		public Document Document {

--- a/Mono.Cecil.Cil/SequencePoint.cs
+++ b/Mono.Cecil.Cil/SequencePoint.cs
@@ -47,7 +47,7 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public bool IsHidden {
-			get { return start_line == 0xfeefee && start_line == end_line; }
+			get { return start_line == 0xfeefee && (start_line == end_line || start_line == start_column); }
 		}
 
 		public Document Document {


### PR DESCRIPTION
According to the [specification](https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md) for the Portable PDB format,

> Hidden sequence point is a sequence point whose Start Line = End Line = 0xfeefee and Start Column = End Column = 0.

That also seems to apply to standard PDBs, at least those I've seen.

This commit only replaces the second half of the existing check, which checked the start column against `0xfeefee`.

Edit: I've admittedly forgotten the tests, yet am wondering why exactly it's failing.