### PR TITLE
[Performance] Improve AddMapping performance by using a List instead …

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -872,25 +872,25 @@ namespace Mono.Cecil {
 
 		public bool HasNestedTypes (TypeDefinition type)
 		{
-			uint [] mapping;
+			Collection<uint> mapping;
 			InitializeNestedTypes ();
 
 			if (!metadata.TryGetNestedTypeMapping (type, out mapping))
 				return false;
 
-			return mapping.Length > 0;
+			return mapping.Count > 0;
 		}
 
 		public Collection<TypeDefinition> ReadNestedTypes (TypeDefinition type)
 		{
 			InitializeNestedTypes ();
-			uint [] mapping;
+			Collection<uint> mapping;
 			if (!metadata.TryGetNestedTypeMapping (type, out mapping))
 				return new MemberDefinitionCollection<TypeDefinition> (type);
 
-			var nested_types = new MemberDefinitionCollection<TypeDefinition> (type, mapping.Length);
+			var nested_types = new MemberDefinitionCollection<TypeDefinition> (type, mapping.Count);
 
-			for (int i = 0; i < mapping.Length; i++) {
+			for (int i = 0; i < mapping.Count; i++) {
 				var nested_type = GetTypeDefinition (mapping [i]);
 
 				if (nested_type != null)
@@ -909,7 +909,7 @@ namespace Mono.Cecil {
 
 			var length = MoveTo (Table.NestedClass);
 
-			metadata.NestedTypes = new Dictionary<uint, uint []> (length);
+			metadata.NestedTypes = new Dictionary<uint, Collection<uint>> (length);
 			metadata.ReverseNestedTypes = new Dictionary<uint, uint> (length);
 
 			if (length == 0)
@@ -929,18 +929,14 @@ namespace Mono.Cecil {
 			metadata.SetReverseNestedTypeMapping (nested, declaring);
 		}
 
-		static TValue [] AddMapping<TKey, TValue> (Dictionary<TKey, TValue []> cache, TKey key, TValue value)
+		static Collection<TValue> AddMapping<TKey, TValue> (Dictionary<TKey, Collection<TValue>> cache, TKey key, TValue value)
 		{
-			TValue [] mapped;
+			Collection<TValue> mapped;
 			if (!cache.TryGetValue (key, out mapped)) {
-				mapped = new [] { value };
-				return mapped;
+				mapped = new Collection<TValue> ();
 			}
-
-			var new_mapped = new TValue [mapped.Length + 1];
-			Array.Copy (mapped, new_mapped, mapped.Length);
-			new_mapped [mapped.Length] = value;
-			return new_mapped;
+			mapped.Add (value);
+			return mapped;
 		}
 
 		TypeDefinition ReadType (uint rid)
@@ -1222,7 +1218,7 @@ namespace Mono.Cecil {
 		public bool HasInterfaces (TypeDefinition type)
 		{
 			InitializeInterfaces ();
-			Row<uint, MetadataToken> [] mapping;
+			Collection<Row<uint, MetadataToken>> mapping;
 
 			return metadata.TryGetInterfaceMapping (type, out mapping);
 		}
@@ -1230,16 +1226,16 @@ namespace Mono.Cecil {
 		public InterfaceImplementationCollection ReadInterfaces (TypeDefinition type)
 		{
 			InitializeInterfaces ();
-			Row<uint, MetadataToken> [] mapping;
+			Collection<Row<uint, MetadataToken>> mapping;
 
 			if (!metadata.TryGetInterfaceMapping (type, out mapping))
 				return new InterfaceImplementationCollection (type);
 
-			var interfaces = new InterfaceImplementationCollection (type, mapping.Length);
+			var interfaces = new InterfaceImplementationCollection (type, mapping.Count);
 
 			this.context = type;
 
-			for (int i = 0; i < mapping.Length; i++) {
+			for (int i = 0; i < mapping.Count; i++) {
 				interfaces.Add (
 					new InterfaceImplementation (
 						GetTypeDefOrRef (mapping [i].Col2),
@@ -1258,7 +1254,7 @@ namespace Mono.Cecil {
 
 			int length = MoveTo (Table.InterfaceImpl);
 
-			metadata.Interfaces = new Dictionary<uint, Row<uint, MetadataToken> []> (length);
+			metadata.Interfaces = new Dictionary<uint, Collection<Row<uint, MetadataToken>>> (length);
 
 			for (uint i = 1; i <= length; i++) {
 				var type = ReadTableIndex (Table.TypeDef);
@@ -2026,26 +2022,26 @@ namespace Mono.Cecil {
 		{
 			InitializeGenericConstraints ();
 
-			MetadataToken [] mapping;
+			Collection<MetadataToken> mapping;
 			if (!metadata.TryGetGenericConstraintMapping (generic_parameter, out mapping))
 				return false;
 
-			return mapping.Length > 0;
+			return mapping.Count > 0;
 		}
 
 		public Collection<TypeReference> ReadGenericConstraints (GenericParameter generic_parameter)
 		{
 			InitializeGenericConstraints ();
 
-			MetadataToken [] mapping;
+			Collection<MetadataToken> mapping;
 			if (!metadata.TryGetGenericConstraintMapping (generic_parameter, out mapping))
 				return new Collection<TypeReference> ();
 
-			var constraints = new Collection<TypeReference> (mapping.Length);
+			var constraints = new Collection<TypeReference> (mapping.Count);
 
 			this.context = (IGenericContext) generic_parameter.Owner;
 
-			for (int i = 0; i < mapping.Length; i++)
+			for (int i = 0; i < mapping.Count; i++)
 				constraints.Add (GetTypeDefOrRef (mapping [i]));
 
 			metadata.RemoveGenericConstraintMapping (generic_parameter);
@@ -2060,7 +2056,7 @@ namespace Mono.Cecil {
 
 			var length = MoveTo (Table.GenericParamConstraint);
 
-			metadata.GenericConstraints = new Dictionary<uint, MetadataToken []> (length);
+			metadata.GenericConstraints = new Dictionary<uint, Collection<MetadataToken>> (length);
 
 			for (int i = 1; i <= length; i++)
 				AddGenericConstraintMapping (
@@ -2078,27 +2074,27 @@ namespace Mono.Cecil {
 		public bool HasOverrides (MethodDefinition method)
 		{
 			InitializeOverrides ();
-			MetadataToken [] mapping;
+			Collection<MetadataToken> mapping;
 
 			if (!metadata.TryGetOverrideMapping (method, out mapping))
 				return false;
 
-			return mapping.Length > 0;
+			return mapping.Count > 0;
 		}
 
 		public Collection<MethodReference> ReadOverrides (MethodDefinition method)
 		{
 			InitializeOverrides ();
 
-			MetadataToken [] mapping;
+			Collection<MetadataToken> mapping;
 			if (!metadata.TryGetOverrideMapping (method, out mapping))
 				return new Collection<MethodReference> ();
 
-			var overrides = new Collection<MethodReference> (mapping.Length);
+			var overrides = new Collection<MethodReference> (mapping.Count);
 
 			this.context = method;
 
-			for (int i = 0; i < mapping.Length; i++)
+			for (int i = 0; i < mapping.Count; i++)
 				overrides.Add ((MethodReference) LookupToken (mapping [i]));
 
 			metadata.RemoveOverrideMapping (method);
@@ -2113,7 +2109,7 @@ namespace Mono.Cecil {
 
 			var length = MoveTo (Table.MethodImpl);
 
-			metadata.Overrides = new Dictionary<uint, MetadataToken []> (length);
+			metadata.Overrides = new Dictionary<uint, Collection<MetadataToken>> (length);
 
 			for (int i = 1; i <= length; i++) {
 				ReadTableIndex (Table.TypeDef);
@@ -2875,7 +2871,7 @@ namespace Mono.Cecil {
 
 			int length = MoveTo (Table.LocalScope);
 
-			metadata.LocalScopes = new Dictionary<uint, Row<uint, Range, Range, uint, uint, uint> []> ();
+			metadata.LocalScopes = new Dictionary<uint, Collection<Row<uint, Range, Range, uint, uint, uint>>> ();
 
 			for (uint i = 1; i <= length; i++) {
 				var method = ReadTableIndex (Table.Method);
@@ -2894,13 +2890,13 @@ namespace Mono.Cecil {
 			InitializeLocalScopes ();
 			InitializeImportScopes ();
 
-			Row<uint, Range, Range, uint, uint, uint> [] records;
+			Collection<Row<uint, Range, Range, uint, uint, uint>> records;
 			if (!metadata.TryGetLocalScopes (method, out records))
 				return null;
 
 			var method_scope = null as ScopeDebugInformation;
 
-			for (int i = 0; i < records.Length; i++) {
+			for (int i = 0; i < records.Count; i++) {
 				var scope = ReadLocalScope (records [i]);
 
 				if (i == 0) {

--- a/Mono.Cecil/MetadataSystem.cs
+++ b/Mono.Cecil/MetadataSystem.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 
 using Mono.Cecil.Cil;
 using Mono.Cecil.Metadata;
+using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
 
@@ -39,15 +40,15 @@ namespace Mono.Cecil {
 		internal MethodDefinition [] Methods;
 		internal MemberReference [] MemberReferences;
 
-		internal Dictionary<uint, uint []> NestedTypes;
+		internal Dictionary<uint, Collection<uint>> NestedTypes;
 		internal Dictionary<uint, uint> ReverseNestedTypes;
-		internal Dictionary<uint, Row<uint, MetadataToken> []> Interfaces;
+		internal Dictionary<uint, Collection<Row<uint, MetadataToken>>> Interfaces;
 		internal Dictionary<uint, Row<ushort, uint>> ClassLayouts;
 		internal Dictionary<uint, uint> FieldLayouts;
 		internal Dictionary<uint, uint> FieldRVAs;
 		internal Dictionary<MetadataToken, uint> FieldMarshals;
 		internal Dictionary<MetadataToken, Row<ElementType, uint>> Constants;
-		internal Dictionary<uint, MetadataToken []> Overrides;
+		internal Dictionary<uint, Collection<MetadataToken>> Overrides;
 		internal Dictionary<MetadataToken, Range []> CustomAttributes;
 		internal Dictionary<MetadataToken, Range []> SecurityDeclarations;
 		internal Dictionary<uint, Range> Events;
@@ -55,10 +56,10 @@ namespace Mono.Cecil {
 		internal Dictionary<uint, Row<MethodSemanticsAttributes, MetadataToken>> Semantics;
 		internal Dictionary<uint, Row<PInvokeAttributes, uint, uint>> PInvokes;
 		internal Dictionary<MetadataToken, Range []> GenericParameters;
-		internal Dictionary<uint, MetadataToken []> GenericConstraints;
+		internal Dictionary<uint, Collection<MetadataToken>> GenericConstraints;
 
 		internal Document [] Documents;
-		internal Dictionary<uint, Row<uint, Range, Range, uint, uint, uint> []> LocalScopes;
+		internal Dictionary<uint, Collection<Row<uint, Range, Range, uint, uint, uint>>> LocalScopes;
 		internal ImportDebugInformation [] ImportScopes;
 		internal Dictionary<uint, uint> StateMachineMethods;
 		internal Dictionary<MetadataToken, Row<Guid, uint, uint> []> CustomDebugInformations;
@@ -132,15 +133,15 @@ namespace Mono.Cecil {
 
 		public void Clear ()
 		{
-			if (NestedTypes != null) NestedTypes = new Dictionary<uint, uint []> (capacity: 0);
+			if (NestedTypes != null) NestedTypes = new Dictionary<uint, Collection<uint>> (capacity: 0);
 			if (ReverseNestedTypes != null) ReverseNestedTypes = new Dictionary<uint, uint> (capacity: 0);
-			if (Interfaces != null) Interfaces = new Dictionary<uint, Row<uint, MetadataToken> []> (capacity: 0);
+			if (Interfaces != null) Interfaces = new Dictionary<uint, Collection<Row<uint, MetadataToken>>> (capacity: 0);
 			if (ClassLayouts != null) ClassLayouts = new Dictionary<uint, Row<ushort, uint>> (capacity: 0);
 			if (FieldLayouts != null) FieldLayouts = new Dictionary<uint, uint> (capacity: 0);
 			if (FieldRVAs != null) FieldRVAs = new Dictionary<uint, uint> (capacity: 0);
 			if (FieldMarshals != null) FieldMarshals = new Dictionary<MetadataToken, uint> (capacity: 0);
 			if (Constants != null) Constants = new Dictionary<MetadataToken, Row<ElementType, uint>> (capacity: 0);
-			if (Overrides != null) Overrides = new Dictionary<uint, MetadataToken []> (capacity: 0);
+			if (Overrides != null) Overrides = new Dictionary<uint, Collection<MetadataToken>> (capacity: 0);
 			if (CustomAttributes != null) CustomAttributes = new Dictionary<MetadataToken, Range []> (capacity: 0);
 			if (SecurityDeclarations != null) SecurityDeclarations = new Dictionary<MetadataToken, Range []> (capacity: 0);
 			if (Events != null) Events = new Dictionary<uint, Range> (capacity: 0);
@@ -148,11 +149,11 @@ namespace Mono.Cecil {
 			if (Semantics != null) Semantics = new Dictionary<uint, Row<MethodSemanticsAttributes, MetadataToken>> (capacity: 0);
 			if (PInvokes != null) PInvokes = new Dictionary<uint, Row<PInvokeAttributes, uint, uint>> (capacity: 0);
 			if (GenericParameters != null) GenericParameters = new Dictionary<MetadataToken, Range []> (capacity: 0);
-			if (GenericConstraints != null) GenericConstraints = new Dictionary<uint, MetadataToken []> (capacity: 0);
+			if (GenericConstraints != null) GenericConstraints = new Dictionary<uint, Collection<MetadataToken>> (capacity: 0);
 
 			Documents = Empty<Document>.Array;
 			ImportScopes = Empty<ImportDebugInformation>.Array;
-			if (LocalScopes != null) LocalScopes = new Dictionary<uint, Row<uint, Range, Range, uint, uint, uint> []> (capacity: 0);
+			if (LocalScopes != null) LocalScopes = new Dictionary<uint, Collection<Row<uint, Range, Range, uint, uint, uint>>> (capacity: 0);
 			if (StateMachineMethods != null) StateMachineMethods = new Dictionary<uint, uint> (capacity: 0);
 		}
 
@@ -229,12 +230,12 @@ namespace Mono.Cecil {
 			MemberReferences [member.token.RID - 1] = member;
 		}
 
-		public bool TryGetNestedTypeMapping (TypeDefinition type, out uint [] mapping)
+		public bool TryGetNestedTypeMapping (TypeDefinition type, out Collection<uint> mapping)
 		{
 			return NestedTypes.TryGetValue (type.token.RID, out mapping);
 		}
 
-		public void SetNestedTypeMapping (uint type_rid, uint [] mapping)
+		public void SetNestedTypeMapping (uint type_rid, Collection<uint> mapping)
 		{
 			NestedTypes [type_rid] = mapping;
 		}
@@ -259,12 +260,12 @@ namespace Mono.Cecil {
 			ReverseNestedTypes.Remove (type.token.RID);
 		}
 
-		public bool TryGetInterfaceMapping (TypeDefinition type, out Row<uint, MetadataToken> [] mapping)
+		public bool TryGetInterfaceMapping (TypeDefinition type, out Collection<Row<uint, MetadataToken>> mapping)
 		{
 			return Interfaces.TryGetValue (type.token.RID, out mapping);
 		}
 
-		public void SetInterfaceMapping (uint type_rid, Row<uint, MetadataToken> [] mapping)
+		public void SetInterfaceMapping (uint type_rid, Collection<Row<uint, MetadataToken>> mapping)
 		{
 			Interfaces [type_rid] = mapping;
 		}
@@ -334,12 +335,12 @@ namespace Mono.Cecil {
 			SecurityDeclarations.Remove (owner.MetadataToken);
 		}
 
-		public bool TryGetGenericConstraintMapping (GenericParameter generic_parameter, out MetadataToken [] mapping)
+		public bool TryGetGenericConstraintMapping (GenericParameter generic_parameter, out Collection<MetadataToken> mapping)
 		{
 			return GenericConstraints.TryGetValue (generic_parameter.token.RID, out mapping);
 		}
 
-		public void SetGenericConstraintMapping (uint gp_rid, MetadataToken [] mapping)
+		public void SetGenericConstraintMapping (uint gp_rid, Collection<MetadataToken> mapping)
 		{
 			GenericConstraints [gp_rid] = mapping;
 		}
@@ -349,12 +350,12 @@ namespace Mono.Cecil {
 			GenericConstraints.Remove (generic_parameter.token.RID);
 		}
 
-		public bool TryGetOverrideMapping (MethodDefinition method, out MetadataToken [] mapping)
+		public bool TryGetOverrideMapping (MethodDefinition method, out Collection<MetadataToken> mapping)
 		{
 			return Overrides.TryGetValue (method.token.RID, out mapping);
 		}
 
-		public void SetOverrideMapping (uint rid, MetadataToken [] mapping)
+		public void SetOverrideMapping (uint rid, Collection<MetadataToken> mapping)
 		{
 			Overrides [rid] = mapping;
 		}
@@ -372,12 +373,12 @@ namespace Mono.Cecil {
 			return Documents [rid - 1];
 		}
 
-		public bool TryGetLocalScopes (MethodDefinition method, out Row<uint, Range, Range, uint, uint, uint> [] scopes)
+		public bool TryGetLocalScopes (MethodDefinition method, out Collection<Row<uint, Range, Range, uint, uint, uint>> scopes)
 		{
 			return LocalScopes.TryGetValue (method.MetadataToken.RID, out scopes);
 		}
 
-		public void SetLocalScopes (uint method_rid, Row<uint, Range, Range, uint, uint, uint> [] records)
+		public void SetLocalScopes (uint method_rid, Collection<Row<uint, Range, Range, uint, uint, uint>> records)
 		{
 			LocalScopes [method_rid] = records;
 		}


### PR DESCRIPTION
…of an Array.

Mono.Cecil is used by mono-addins to scan all addin assemblies. In this
case, we request the types from a given assembly, which goes through the
nested types cache mapping.

A hot path in this case was AssemblyReader.AddMapping, which was doing a
lot of array resizing in the end.

Using mono-addins inside MonoDevelop would allocate 31MB of arrays.

MetadataReader.InitializeTypeDefinitions would allocate 57MB before, and
now it's down to 27MB.

The CPU time is also down now, from 117ms to 71ms.