### PR TITLE
Added .editorconfig to use indent_style tabs (for VS2017)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# top-most EditorConfig file
+root = true
+
+[*.cs]
+indent_style = tab

--- a/symbols/pdb/Microsoft.Cci.Pdb/.editorconfig
+++ b/symbols/pdb/Microsoft.Cci.Pdb/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Trying to bring some happiness to VS users, this one is going to make contributions to Cecil much easier 😄 

So far I spent really a **lot** of time cleaning up my commits from tabs to space (and often missing spots) due to VS2015- having this setting global.
Until now I have always wished Cecil switched to indent spaces only due to this VS limitation, but now MS finally solved it so that it doesn't matter anymore!