### PR TITLE
Open file with ReadWrite share mode if ReaderParameters.ReadWrite is true

### DIFF
--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -1100,7 +1100,7 @@ namespace Mono.Cecil {
 
 		public static ModuleDefinition ReadModule (string fileName, ReaderParameters parameters)
 		{
-			var stream = GetFileStream (fileName, FileMode.Open, parameters.ReadWrite ? FileAccess.ReadWrite : FileAccess.Read, FileShare.Read);
+			var stream = GetFileStream (fileName, FileMode.Open, parameters.ReadWrite ? FileAccess.ReadWrite : FileAccess.Read, parameters.ReadWrite ? FileShare.ReadWrite : FileShare.Read);
 
 			if (parameters.InMemory) {
 				var memory = new MemoryStream (stream.CanSeek ? (int) stream.Length : 0);


### PR DESCRIPTION
Had cases where I wanted to open an assembly in ReadWrite and also open it as a separate Stream in another thread (and ideally want to avoid passing stream around) or process.