### PR TITLE
FileShare can be customized when writing back the assembly

### DIFF
--- a/Mono.Cecil/AssemblyDefinition.cs
+++ b/Mono.Cecil/AssemblyDefinition.cs
@@ -163,9 +163,9 @@ namespace Mono.Cecil {
 			Write (fileName, new WriterParameters ());
 		}
 
-		public void Write (string fileName, WriterParameters parameters)
+		public void Write (string fileName, WriterParameters parameters, FileShare share = FileShare.None)
 		{
-			main_module.Write (fileName, parameters);
+			main_module.Write (fileName, parameters, share);
 		}
 #endif
 

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -1157,10 +1157,10 @@ namespace Mono.Cecil {
 			Write (fileName, new WriterParameters ());
 		}
 
-		public void Write (string fileName, WriterParameters parameters)
+		public void Write (string fileName, WriterParameters parameters, FileShare share = FileShare.None)
 		{
 			Mixin.CheckParameters (parameters);
-			var file = GetFileStream (fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+			var file = GetFileStream (fileName, FileMode.Create, FileAccess.ReadWrite, share);
 			ModuleWriter.WriteModuleTo (this, Disposable.Owned (file), parameters);
 		}
 #endif


### PR DESCRIPTION
Notes:
-  could also become a parameter in WriterParameters, but that wouldn't make sense when saving back a Stream, only with the fileName override when Cecil creates the stream -- let me know what you prefer
- Ideally, I could give an already opened stream but most `ISymbolWriterProvider.GetSymbolWriter(Stream)` are unimplemented. Of course, it is not easy because we would either want to provide user facility to determine SymbolStream filename on his own (to avoid hardcoding symbol file probing), and/or (as a fallback?) detect if Stream is a FileStream and fallback to file version?