### PR TITLE
Allow creation of AsyncMethodBodyDebugInformation with a null catch handler (encoded as offset -1 internally)

### DIFF
--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -514,6 +514,12 @@ namespace Mono.Cecil.Cil {
 		{
 			this.catch_handler = new InstructionOffset (catchHandler);
 		}
+
+		public AsyncMethodBodyDebugInformation ()
+			: base (KindIdentifier)
+		{
+			this.catch_handler = new InstructionOffset (-1);
+		}
 	}
 
 	public sealed class StateMachineScopeDebugInformation : CustomDebugInformation {


### PR DESCRIPTION
Would it be OK that way?