### PR TITLE
Enable restoring of Cecil as a P2P reference in .NET Core

### DIFF
--- a/Mono.Cecil.csproj
+++ b/Mono.Cecil.csproj
@@ -16,5 +16,5 @@
     <Compile Include="Mono.Security.Cryptography\*.cs" />
   </ItemGroup>
   <Import Project="Mono.Cecil.props" />
-  <Import Project="$(MSBuildCSharpTargets)" Condition=" ! $(Configuration.StartsWith('netstandard')) " />
+  <Import Project="$(MSBuildCSharpTargets)" Condition=" ! $(NetStandard) " />
 </Project>

--- a/Mono.Cecil.props
+++ b/Mono.Cecil.props
@@ -12,6 +12,8 @@
     <OutputType>Library</OutputType>
     <OutputPath>$(BuildDirectory)\bin\$(Configuration)\</OutputPath>
     <MSBuildCSharpTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</MSBuildCSharpTargets>
+    <NetStandard Condition=" $(Configuration.StartsWith('netstandard')) Or '$(NuGetRestoreTargets)' != '' ">true</NetStandard>
+    <NetStandard Condition=" '$(NetStandard)' == '' ">false</NetStandard>
   </PropertyGroup>
   <PropertyGroup Condition=" $(Configuration.EndsWith('Debug')) ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,12 +39,12 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <DefineConstants>$(DefineConstants);NET_4_0;</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" $(Configuration.StartsWith('netstandard')) ">
+  <PropertyGroup Condition=" $(NetStandard) ">
     <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
-  <Import Project="NetStandard.props"  Condition=" $(Configuration.StartsWith('netstandard')) " />
+  <Import Project="NetStandard.props"  Condition=" $(NetStandard) " />
   <!-- Shared References -->
-  <ItemGroup Condition=" ! $(Configuration.StartsWith('netstandard')) ">
+  <ItemGroup Condition=" ! $(NetStandard) ">
     <Reference Include="System.Core" />
     <Reference Include="System" />
   </ItemGroup>

--- a/rocks/Mono.Cecil.Rocks.csproj
+++ b/rocks/Mono.Cecil.Rocks.csproj
@@ -16,7 +16,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\Mono.Cecil.props" />
-  <Import Project="$(MSBuildCSharpTargets)" Condition=" ! $(Configuration.StartsWith('netstandard')) " />
+  <Import Project="$(MSBuildCSharpTargets)" Condition=" ! $(NetStandard) " />
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);INSIDE_ROCKS</DefineConstants>
   </PropertyGroup>

--- a/symbols/mdb/Mono.Cecil.Mdb.csproj
+++ b/symbols/mdb/Mono.Cecil.Mdb.csproj
@@ -17,7 +17,7 @@
     <Compile Include="Mono.CompilerServices.SymbolWriter\*.cs" />
   </ItemGroup>
   <Import Project="..\..\Mono.Cecil.props" />
-  <Import Project="$(MSBuildCSharpTargets)" Condition=" ! $(Configuration.StartsWith('netstandard')) " />
+  <Import Project="$(MSBuildCSharpTargets)" Condition=" ! $(NetStandard) " />
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);CECIL</DefineConstants>
   </PropertyGroup>

--- a/symbols/pdb/Mono.Cecil.Pdb.csproj
+++ b/symbols/pdb/Mono.Cecil.Pdb.csproj
@@ -18,5 +18,5 @@
     <Compile Include="Mono.Cecil.Pdb\*.cs" />
   </ItemGroup>
   <Import Project="..\..\Mono.Cecil.props" />
-  <Import Project="$(MSBuildCSharpTargets)" Condition=" ! $(Configuration.StartsWith('netstandard')) " />
+  <Import Project="$(MSBuildCSharpTargets)" Condition=" ! $(NetStandard) " />
 </Project>


### PR DESCRIPTION
A NuGet bug (https://github.com/NuGet/Home/issues/4873) causes the
configuration not to be set during restore when using Cecil as a
ProjectReference of another project using the .NET Core cli tooling.

Until that bug is fixed, this workaround will correctly import
NetStandard.props by checking for the existence of an msbuild property
that is set during restore using the new tooling.