### PR TITLE
Upstream dont call windowsruntime during read

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Author:
 //   Jb Evain (jbevain@gmail.com)
 //
@@ -837,6 +837,12 @@ namespace Mono.Cecil {
 
 				types [i] = ReadType (i + 1);
 			}
+
+			if (module.IsWindowsMetadata()) {
+				for (uint i = 0; i < length; i++) {
+					WindowsRuntimeProjections.Project (types [i]);
+				}
+			}
 		}
 
 		static bool IsNested (TypeAttributes attributes)
@@ -947,9 +953,6 @@ namespace Mono.Cecil {
 
 			if (IsNested (attributes))
 				type.DeclaringType = GetNestedTypeDeclaringType (type);
-
-			if (module.IsWindowsMetadata ())
-				WindowsRuntimeProjections.Project (type);
 
 			return type;
 		}

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Author:
 //   Jb Evain (jbevain@gmail.com)
 //
@@ -838,7 +838,7 @@ namespace Mono.Cecil {
 				types [i] = ReadType (i + 1);
 			}
 
-			if (module.IsWindowsMetadata()) {
+			if (module.IsWindowsMetadata ()) {
 				for (uint i = 0; i < length; i++) {
 					WindowsRuntimeProjections.Project (types [i]);
 				}
@@ -1050,9 +1050,8 @@ namespace Mono.Cecil {
 
 			type = ReadTypeDefinition (rid);
 
-			if (module.IsWindowsMetadata()) {
+			if (module.IsWindowsMetadata ())
 				WindowsRuntimeProjections.Project (type);
-			}
 
 			return type;
 		}

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -1045,7 +1045,13 @@ namespace Mono.Cecil {
 			if (type != null)
 				return type;
 
-			return ReadTypeDefinition (rid);
+			type = ReadTypeDefinition (rid);
+
+			if (module.IsWindowsMetadata()) {
+				WindowsRuntimeProjections.Project (type);
+			}
+
+			return type;
 		}
 
 		TypeDefinition ReadTypeDefinition (uint rid)


### PR DESCRIPTION
We found a crash deep in the metadata reading code when Windows Runtime projections are calculated before the type is fully read. This showed up with the latest Xbox One SDK.