### PR TITLE
Dispose stream in WriteModuleTo on .NET Core

### DIFF
--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -122,9 +122,8 @@ namespace Mono.Cecil {
 #if !NET_CORE
 			if (parameters.StrongNameKeyPair != null)
 				CryptoService.StrongName (stream.value, writer, parameters.StrongNameKeyPair);
-
-			stream.Dispose ();
 #endif
+			stream.Dispose ();
 		}
 
 		static void BuildMetadata (ModuleDefinition module, MetadataBuilder metadata)


### PR DESCRIPTION
This fixes a bug I was encountering on windows in which a subsequent attempt to open the file in the same process failed.