### PR TITLE
Release lock on file when exception in ModuleWriter.WriteModuleTo

### DIFF
--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using SR = System.Reflection;
@@ -1119,7 +1118,6 @@ namespace Mono.Cecil {
 
 		public void Write (string fileName, WriterParameters parameters)
 		{
-			Debugger.Launch ();
 			Mixin.CheckParameters (parameters);
 			var file = GetFileStream (fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
 			ModuleWriter.WriteModuleTo (this, Disposable.Owned (file), parameters);

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using SR = System.Reflection;
@@ -1118,6 +1119,7 @@ namespace Mono.Cecil {
 
 		public void Write (string fileName, WriterParameters parameters)
 		{
+			Debugger.Launch ();
 			Mixin.CheckParameters (parameters);
 			var file = GetFileStream (fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
 			ModuleWriter.WriteModuleTo (this, Disposable.Owned (file), parameters);

--- a/Test/Mono.Cecil.Tests/ModuleTests.cs
+++ b/Test/Mono.Cecil.Tests/ModuleTests.cs
@@ -294,5 +294,28 @@ namespace Mono.Cecil.Tests {
 			using (var module = ModuleDefinition.ReadModule (path))
 				Assert.AreEqual ("Foo.Foo", module.Types [1].FullName);
 		}
+
+		[Test]
+		public void ExceptionInWriteDoesNotKeepLockOnFile ()
+		{
+			var path = Path.GetTempFileName ();
+
+			var original = ModuleDefinition.CreateModule ("FooFoo", ModuleKind.Dll);
+			var type = new TypeDefinition ("Foo", "Foo", TypeAttributes.Abstract | TypeAttributes.Sealed);
+			original.Types.Add (type);
+			original.Attributes = 0;      // Force an exception
+			try
+			{
+				original.Write(path);
+				Assert.Fail("Exception should have been thrown");
+			}
+			catch
+			{
+				// Expected
+			}
+
+			// Ensure you can still delete the file
+			File.Delete (path);
+		}
 	}
 }


### PR DESCRIPTION
Currently, if an exception occurs in `ModuleWriter.WriteModuleTo` and the `Disposable<Stream>` is "owned", `Dispose()` will not be called, and the file will be locked.  

For example, in a `Fody` plugin, if this situation arises, then one must manually kill `MsBuild.exe` in order to release the lock.  I think probably `Dispose()` ought to be called in all circumstances.  (Currently, an exception can arise with Fody if you take a loaded `MethodDefinition` for a method that contains a local variable and assign it a new `MethodBody` the cached debug info becomes invalid and an exception will occur.   But I'll file a separate PR for that)

* Add a unit test verifying the problem/fix
* Surround method body with a try/finally