### PR TITLE
Delay-sign cecil assemblies for .NET Core build

### DIFF
--- a/NetStandard.props
+++ b/NetStandard.props
@@ -5,5 +5,6 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Delay-signing cecil is necessary so that we can authenticode-sign cecil for .NET core as part of the linker build. I'm not sure if this is an acceptable default for the cecil project, so please let me know if there's a better way to do this. Ideally I would like to isolate cecil's project files from the changes necessary in the linker build, but I don't see a great way to do this with submodules.

An alternative to this would be to enable authenticode signing in the cecil project, but that would probably involve even more intrusive changes to cecil.

Thoughts?