### PR TITLE
Allow for processor architecture when resolving

### DIFF
--- a/Mono.Cecil.PE/Image.cs
+++ b/Mono.Cecil.PE/Image.cs
@@ -26,7 +26,7 @@ namespace Mono.Cecil.PE {
 
 		public ModuleKind Kind;
 		public string RuntimeVersion;
-		public TargetArchitecture Architecture;
+		public ProcessorArchitecture Architecture;
 		public ModuleCharacteristics Characteristics;
 
 		public ImageDebugHeader DebugHeader;

--- a/Mono.Cecil.PE/ImageReader.cs
+++ b/Mono.Cecil.PE/ImageReader.cs
@@ -92,9 +92,9 @@ namespace Mono.Cecil.PE {
 			image.Characteristics = (ModuleCharacteristics) dll_characteristics;
 		}
 
-		TargetArchitecture ReadArchitecture ()
+		ProcessorArchitecture ReadArchitecture ()
 		{
-			return (TargetArchitecture) ReadUInt16 ();
+			return (ProcessorArchitecture) ReadUInt16 ();
 		}
 
 		static ModuleKind GetModuleKind (ushort characteristics, ushort subsystem)

--- a/Mono.Cecil.PE/ImageWriter.cs
+++ b/Mono.Cecil.PE/ImageWriter.cs
@@ -61,8 +61,8 @@ namespace Mono.Cecil.PE {
 			if (metadataOnly)
 				return;
 
-			this.pe64 = module.Architecture == TargetArchitecture.AMD64 || module.Architecture == TargetArchitecture.IA64 || module.Architecture == TargetArchitecture.ARM64;
-			this.has_reloc = module.Architecture == TargetArchitecture.I386;
+			this.pe64 = module.Architecture == ProcessorArchitecture.AMD64 || module.Architecture == ProcessorArchitecture.IA64 || module.Architecture == ProcessorArchitecture.ARM64;
+			this.has_reloc = module.Architecture == ProcessorArchitecture.I386;
 			this.GetDebugHeader ();
 			this.GetWin32Resources ();
 			this.BuildTextMap ();
@@ -632,7 +632,7 @@ namespace Mono.Cecil.PE {
 		void WriteStartupStub ()
 		{
 			switch (module.Architecture) {
-			case TargetArchitecture.I386:
+			case ProcessorArchitecture.I386:
 				WriteUInt16 (0x25ff);
 				WriteUInt32 ((uint) image_base + text_map.GetRVA (TextSegment.ImportAddressTable));
 				return;
@@ -652,14 +652,14 @@ namespace Mono.Cecil.PE {
 			PrepareSection (reloc);
 
 			var reloc_rva = text_map.GetRVA (TextSegment.StartupStub);
-			reloc_rva += module.Architecture == TargetArchitecture.IA64 ? 0x20u : 2;
+			reloc_rva += module.Architecture == ProcessorArchitecture.IA64 ? 0x20u : 2;
 			var page_rva = reloc_rva & ~0xfffu;
 
 			WriteUInt32 (page_rva);	// PageRVA
 			WriteUInt32 (0x000c);	// Block Size
 
 			switch (module.Architecture) {
-			case TargetArchitecture.I386:
+			case ProcessorArchitecture.I386:
 				WriteUInt32 (0x3000 + reloc_rva - page_rva);
 				break;
 			default:
@@ -730,7 +730,7 @@ namespace Mono.Cecil.PE {
 			uint import_dir_len = (import_hnt_rva - import_dir_rva) + 27u;
 
 			RVA startup_stub_rva = import_dir_rva + import_dir_len;
-			startup_stub_rva = module.Architecture == TargetArchitecture.IA64
+			startup_stub_rva = module.Architecture == ProcessorArchitecture.IA64
 				? (startup_stub_rva + 15u) & ~15u
 				: 2 + ((startup_stub_rva + 3u) & ~3u);
 
@@ -755,7 +755,7 @@ namespace Mono.Cecil.PE {
 		uint GetStartupStubLength ()
 		{
 			switch (module.Architecture) {
-			case TargetArchitecture.I386:
+			case ProcessorArchitecture.I386:
 				return 6;
 			default:
 				throw new NotSupportedException ();

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -959,7 +959,7 @@ namespace Mono.Cecil {
 		TextMap CreateTextMap ()
 		{
 			var map = new TextMap ();
-			map.AddMap (TextSegment.ImportAddressTable, module.Architecture == TargetArchitecture.I386 ? 8 : 0);
+			map.AddMap (TextSegment.ImportAddressTable, module.Architecture == ProcessorArchitecture.I386 ? 8 : 0);
 			map.AddMap (TextSegment.CLIHeader, 0x48, 8);
 			return map;
 		}

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -41,8 +41,22 @@ namespace Mono.Cecil {
 		bool projections;
 		bool in_memory;
 		bool read_write;
+		bool allow_any_corlib;
+		TargetArchitecture target_architecture;
 
-		public ReadingMode ReadingMode {
+		public bool AllowAnyCorlib
+		{
+			get { return allow_any_corlib; }
+			set { allow_any_corlib = value; }
+		}
+
+		public TargetArchitecture TargetArchitecture
+		{
+			get { return target_architecture; }
+			set { target_architecture = value; }
+		}
+
+        public ReadingMode ReadingMode {
 			get { return reading_mode; }
 			set { reading_mode = value; }
 		}
@@ -99,14 +113,14 @@ namespace Mono.Cecil {
 			set { projections = value; }
 		}
 
-		public ReaderParameters ()
-			: this (ReadingMode.Deferred)
+		public ReaderParameters() : this(ReadingMode.Deferred)
 		{
 		}
 
-		public ReaderParameters (ReadingMode readingMode)
+		public ReaderParameters(ReadingMode readingMode)
 		{
 			this.reading_mode = readingMode;
+			this.allow_any_corlib = true;
 		}
 	}
 
@@ -117,7 +131,7 @@ namespace Mono.Cecil {
 		ModuleKind kind;
 		TargetRuntime runtime;
 		uint? timestamp;
-		TargetArchitecture architecture;
+		ProcessorArchitecture architecture;
 		IAssemblyResolver assembly_resolver;
 		IMetadataResolver metadata_resolver;
 #if !READ_ONLY
@@ -140,7 +154,7 @@ namespace Mono.Cecil {
 			set { timestamp = value; }
 		}
 
-		public TargetArchitecture Architecture {
+		public ProcessorArchitecture Architecture {
 			get { return architecture; }
 			set { architecture = value; }
 		}
@@ -171,7 +185,7 @@ namespace Mono.Cecil {
 		{
 			this.kind = ModuleKind.Dll;
 			this.Runtime = GetCurrentRuntime ();
-			this.architecture = TargetArchitecture.I386;
+			this.architecture = ProcessorArchitecture.I386;
 		}
 
 		static TargetRuntime GetCurrentRuntime ()
@@ -257,7 +271,7 @@ namespace Mono.Cecil {
 		WindowsRuntimeProjections projections;
 		MetadataKind metadata_kind;
 		TargetRuntime runtime;
-		TargetArchitecture architecture;
+		ProcessorArchitecture architecture;
 		ModuleAttributes attributes;
 		ModuleCharacteristics characteristics;
 		Guid mvid;
@@ -318,7 +332,7 @@ namespace Mono.Cecil {
 			}
 		}
 
-		public TargetArchitecture Architecture {
+		public ProcessorArchitecture Architecture {
 			get { return architecture; }
 			set { architecture = value; }
 		}

--- a/Mono.Cecil/ModuleKind.cs
+++ b/Mono.Cecil/ModuleKind.cs
@@ -25,7 +25,7 @@ namespace Mono.Cecil {
 		ManagedWindowsMetadata,
 	}
 
-	public enum TargetArchitecture {
+	public enum ProcessorArchitecture {
 		I386 = 0x014c,
 		AMD64 = 0x8664,
 		IA64 = 0x0200,
@@ -34,12 +34,23 @@ namespace Mono.Cecil {
 		ARM64 = 0xaa64,
 	}
 
-	[Flags]
+    public enum TargetArchitecture {
+        Any = 0,
+        x86,
+        x64,
+	    ILOnly,
+	    x86Only,
+		x64Only,
+		ARM,
+		ARMOnly
+	}
+
+    [Flags]
 	public enum ModuleAttributes {
 		ILOnly = 1,
 		Required32Bit = 2,
 		StrongNameSigned = 8,
-		Preferred32Bit = 0x00020000,
+		Preferred32Bit = 0x20000,
 	}
 
 	[Flags]

--- a/Test/Mono.Cecil.Tests/ImageReadTests.cs
+++ b/Test/Mono.Cecil.Tests/ImageReadTests.cs
@@ -95,7 +95,7 @@ namespace Mono.Cecil.Tests {
 		public void X64Module ()
 		{
 			TestModule ("hello.x64.exe", module => {
-				Assert.AreEqual (TargetArchitecture.AMD64, module.Image.Architecture);
+				Assert.AreEqual (ProcessorArchitecture.AMD64, module.Image.Architecture);
 				Assert.AreEqual (ModuleAttributes.ILOnly, module.Image.Attributes);
 			}, verify: !Platform.OnMono);
 		}
@@ -104,7 +104,7 @@ namespace Mono.Cecil.Tests {
 		public void X64ModuleTextOnlySection ()
 		{
 			TestModule ("hello.textonly.x64.exe", module => {
-				Assert.AreEqual (TargetArchitecture.AMD64, module.Image.Architecture);
+				Assert.AreEqual (ProcessorArchitecture.AMD64, module.Image.Architecture);
 				Assert.AreEqual (ModuleAttributes.ILOnly, module.Image.Attributes);
 			}, verify: !Platform.OnMono);
 		}
@@ -113,7 +113,7 @@ namespace Mono.Cecil.Tests {
 		public void IA64Module ()
 		{
 			TestModule ("hello.ia64.exe", module => {
-				Assert.AreEqual (TargetArchitecture.IA64, module.Image.Architecture);
+				Assert.AreEqual (ProcessorArchitecture.IA64, module.Image.Architecture);
 				Assert.AreEqual (ModuleAttributes.ILOnly, module.Image.Attributes);
 			}, verify: !Platform.OnMono);
 		}
@@ -122,7 +122,7 @@ namespace Mono.Cecil.Tests {
 		public void X86Module ()
 		{
 			TestModule ("hello.x86.exe", module => {
-				Assert.AreEqual (TargetArchitecture.I386, module.Image.Architecture);
+				Assert.AreEqual (ProcessorArchitecture.I386, module.Image.Architecture);
 				Assert.AreEqual (ModuleAttributes.ILOnly | ModuleAttributes.Required32Bit, module.Image.Attributes);
 			});
 		}
@@ -131,7 +131,7 @@ namespace Mono.Cecil.Tests {
 		public void AnyCpuModule ()
 		{
 			TestModule ("hello.anycpu.exe", module => {
-				Assert.AreEqual (TargetArchitecture.I386, module.Image.Architecture);
+				Assert.AreEqual (ProcessorArchitecture.I386, module.Image.Architecture);
 				Assert.AreEqual (ModuleAttributes.ILOnly, module.Image.Attributes);
 			});
 		}


### PR DESCRIPTION
One of the problems I've run into with the existing `BaseAssemblyResolver` is that it will resolve on a first-seen wins basis so that you can have 64-bit GAC assemblies being returned for pure 32-bit applications, and even the wrong mscorlib. Although on the surface they're the same usually, technically they're not.

To resolve this I've reworked significant portions of the `BaseAssemblyResolver` to now accept a target architecture. 

I have renamed the existing `TargetArchitecture` to `ProcessorArchitecture` which I would argue is what it should really be. I then introduced a new `TargetArchitecture` enum with the following values:

- `Any` - Allow anything, this is the default (and existing) behaviour.
- `ILOnly` - Resolve only pure IL assemblies.
- `x86` - Resolve x86 assemblies and IL assemblies.
- `x86Only` - Resolve only x86 assemblies.
- `x64` - Resolve x64 assemblies and IL assemblies.
- `x64Only` - Resolve only x64 assemblies.
- `ARM*` - Not currently processed, not quite sure what to do with these.

When resolving GAC based assemblies the resolver will now first collect all matching assemblies rather than just return the first. It will then run through this list of matches and filter out any incompatible architectures before returning the top result of the filtered set.

For individual assemblies I've also modified the `GetAssembly` method so that it runs through a similar filtering process and will return `null` if it cannot find a match.

You can set `TargetArchitecture` as part of the `ReaderParameters` class. 

I also ran into an issue with the way `mscorlib` is resolved. At present the filename is got using something like this:

```
var fileName = typeof(object).Module.FullyQualifiedName;
```

The problem with this is that the `mscorlib` is based on the executing process architecture and _not_ the actual architecture that's relevant to the resolution.

So I now try and get it from the GAC first (using all of the above), failing that and if another new propery on `ReaderParameters` called `AllowAnyCorlib` is `false`, will return `null`. By default however it's `true` to keep existing behaviour.

A concrete example of use:

```
if (Executable.Is64Bit)
{
	targetArchitecture = TargetArchitecture.x64;
}
else if (Executable.Is32Bit)
{
	targetArchitecture = TargetArchitecture.x86;
	
	if (Environment.Is64BitOperatingSystem && !Executable.IsCLR32BitPreferred && !Executable.IsCLR32BitRequired)
		targetArchitecture = TargetArchitecture.x64;
}

var readerParams = new ReaderParameters() {
	AssemblyResolver = new AssemblyResolver(this),
	AllowAnyCorlib = false,
	TargetArchitecture = targetArchitecture
};
var moduleDef = ModuleDefinition.ReadModule(Executable.Filename, readerParams);
```

