### PR TITLE
Adding IMethodBody interface to allow different kinds of body implementations

### DIFF
--- a/Mono.Cecil.Cil/CodeWriter.cs
+++ b/Mono.Cecil.Cil/CodeWriter.cs
@@ -50,7 +50,7 @@ namespace Mono.Cecil.Cil {
 
 				rva = WriteUnresolvedMethodBody (method);
 			} else {
-				if (IsEmptyMethodBody (method.Body))
+				if (IsEmptyMethodBody (method.Body.AsILMethodBody()))
 					return 0;
 
 				rva = WriteResolvedMethodBody (method);
@@ -104,7 +104,7 @@ namespace Mono.Cecil.Cil {
 		{
 			RVA rva;
 
-			body = method.Body;
+			body = method.Body.AsILMethodBody();
 			ComputeHeader ();
 			if (RequiresFatHeader ()) {
 				Align (4);

--- a/Mono.Cecil.Cil/MethodBody.cs
+++ b/Mono.Cecil.Cil/MethodBody.cs
@@ -15,7 +15,12 @@ using Mono.Collections.Generic;
 
 namespace Mono.Cecil.Cil {
 
-	public sealed class MethodBody {
+	public interface IMethodBody {
+
+		MethodDefinition Method { get; }
+	}
+
+	public sealed class MethodBody : IMethodBody {
 
 		readonly internal MethodDefinition method;
 
@@ -243,6 +248,26 @@ namespace Mono.Cecil.Cil {
 					return;
 				}
 			}
+		}
+	}
+}
+
+namespace Mono.Cecil
+{
+	using Mono.Cecil.Cil;
+
+	static partial class Mixin
+	{
+
+		public static MethodBody AsILMethodBody(this IMethodBody self)
+		{
+			return self.As<MethodBody>();
+		}
+
+		public static T As<T>(this IMethodBody self)
+			where T : class, IMethodBody
+		{
+			return self == null ? null : (T)self;
 		}
 	}
 }

--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -674,7 +674,8 @@ namespace Mono.Cecil.Cil {
 			for (int i = 0; i < sequence_points.Count; i++)
 				offset_mapping.Add (sequence_points [i].Offset, sequence_points [i]);
 
-			var instructions = method.Body.Instructions;
+			var body = method.Body.AsILMethodBody();
+			var instructions = body.Instructions;
 
 			for (int i = 0; i < instructions.Count; i++) {
 				SequencePoint sequence_point;

--- a/Mono.Cecil/MethodDefinition.cs
+++ b/Mono.Cecil/MethodDefinition.cs
@@ -29,7 +29,7 @@ namespace Mono.Cecil {
 		internal PInvokeInfo pinvoke;
 		Collection<MethodReference> overrides;
 
-		internal MethodBody body;
+		internal IMethodBody body;
 		internal MethodDebugInformation debug_info;
 		internal Collection<CustomDebugInformation> custom_infos;
 
@@ -141,9 +141,9 @@ namespace Mono.Cecil {
 			}
 		}
 
-		public MethodBody Body {
+		public IMethodBody Body {
 			get {
-				MethodBody localBody = this.body;
+				IMethodBody localBody = this.body;
 				if (localBody != null)
 					return localBody;
 

--- a/Test/Mono.Cecil.Tests/Formatter.cs
+++ b/Test/Mono.Cecil.Tests/Formatter.cs
@@ -23,7 +23,7 @@ namespace Mono.Cecil.Tests {
 
 		public static void WriteMethodBody (TextWriter writer, MethodDefinition method)
 		{
-			var body = method.Body;
+			var body = method.Body.AsILMethodBody();
 
 			WriteVariables (writer, body);
 

--- a/Test/Mono.Cecil.Tests/ILProcessorTests.cs
+++ b/Test/Mono.Cecil.Tests/ILProcessorTests.cs
@@ -68,12 +68,13 @@ namespace Mono.Cecil.Tests {
 				Name = "function",
 			};
 
-			var il = method.Body.GetILProcessor ();
+			var body = method.Body.AsILMethodBody();
+			var il = body.GetILProcessor ();
 
 			foreach (var opcode in opcodes)
 				il.Emit (opcode);
 
-			return method.Body;
+			return body;
 		}
 	}
 }

--- a/Test/Mono.Cecil.Tests/ImportCecilTests.cs
+++ b/Test/Mono.Cecil.Tests/ImportCecilTests.cs
@@ -35,7 +35,8 @@ namespace Mono.Cecil.Tests {
 				method_by_ref.Parameters.Add (new ParameterDefinition (module.ImportReference (typeof (string).ToDefinition ())));
 				method_by_ref.Parameters.Add (new ParameterDefinition (module.ImportReference (new ByReferenceType (typeof (string).ToDefinition ()))));
 
-				var m_il = method_by_ref.Body.GetILProcessor ();
+				var method_by_ref_body = method_by_ref.Body.AsILMethodBody();
+				var m_il = method_by_ref_body.GetILProcessor ();
 				m_il.Emit (OpCodes.Ldarg_1);
 				m_il.Emit (OpCodes.Ldarg_0);
 				m_il.Emit (OpCodes.Stind_Ref);
@@ -333,7 +334,7 @@ namespace Mono.Cecil.Tests {
 
 			var method = CreateMethod (type, typeof (TDelegate).GetMethod ("Invoke"));
 
-			emitter (module, method.Body);
+			emitter (module, method.Body.AsILMethodBody());
 
 			return module;
 		}

--- a/Test/Mono.Cecil.Tests/ImportReflectionTests.cs
+++ b/Test/Mono.Cecil.Tests/ImportReflectionTests.cs
@@ -60,7 +60,8 @@ namespace Mono.Cecil.Tests {
 				method_by_ref.Parameters.Add (new ParameterDefinition (module.ImportReference (typeof (string))));
 				method_by_ref.Parameters.Add (new ParameterDefinition (module.ImportReference (typeof (string).MakeByRefType ())));
 
-				var m_il = method_by_ref.Body.GetILProcessor ();
+				var method_by_ref_body = method_by_ref.Body.AsILMethodBody();
+				var m_il = method_by_ref_body.GetILProcessor ();
 				m_il.Emit (OpCodes.Ldarg_1);
 				m_il.Emit (OpCodes.Ldarg_0);
 				m_il.Emit (OpCodes.Stind_Ref);
@@ -380,7 +381,7 @@ namespace Mono.Cecil.Tests {
 
 			var method = CreateMethod (type, typeof (TDelegate).GetMethod ("Invoke"));
 
-			emitter (module, method.Body);
+			emitter (module, method.Body.AsILMethodBody());
 
 			return module;
 		}

--- a/Test/Mono.Cecil.Tests/MethodBodyTests.cs
+++ b/Test/Mono.Cecil.Tests/MethodBodyTests.cs
@@ -216,8 +216,10 @@ namespace Mono.Cecil.Tests {
 	IL_0005: ret
 ", method);
 
-				Assert.AreEqual (method.Body.ThisParameter.ParameterType, type);
-				Assert.AreEqual (method.Body.ThisParameter, method.Body.Instructions [0].Operand);
+				var body = method.Body.AsILMethodBody();
+
+				Assert.AreEqual (body.ThisParameter.ParameterType, type);
+				Assert.AreEqual (body.ThisParameter, body.Instructions [0].Operand);
 			});
 		}
 
@@ -225,7 +227,9 @@ namespace Mono.Cecil.Tests {
 		public void ThisParameterStaticMethod ()
 		{
 			var static_method = typeof (ModuleDefinition).ToDefinition ().Methods.Where (m => m.IsStatic).First ();
-			Assert.IsNull (static_method.Body.ThisParameter);
+			var body = static_method.Body.AsILMethodBody();
+
+			Assert.IsNull (body.ThisParameter);
 		}
 
 		[Test]
@@ -235,7 +239,8 @@ namespace Mono.Cecil.Tests {
 			var int_to_string = int32.Methods.Where (m => m.Name == "ToString" && m.Parameters.Count == 0).First();
 			Assert.IsNotNull (int_to_string);
 
-			var this_parameter_type = int_to_string.Body.ThisParameter.ParameterType;
+			var body = int_to_string.Body.AsILMethodBody();
+			var this_parameter_type = body.ThisParameter.ParameterType;
 			Assert.IsTrue (this_parameter_type.IsByReference);
 
 			var element_type = ((ByReferenceType) this_parameter_type).ElementType;
@@ -249,7 +254,8 @@ namespace Mono.Cecil.Tests {
 			var token_to_string = token.Methods.Where (m => m.Name == "ToString" && m.Parameters.Count == 0).First ();
 			Assert.IsNotNull (token_to_string);
 
-			var this_parameter_type = token_to_string.Body.ThisParameter.ParameterType;
+			var body = token_to_string.Body.AsILMethodBody();
+			var this_parameter_type = body.ThisParameter.ParameterType;
 			Assert.IsTrue (this_parameter_type.IsByReference);
 
 			var element_type = ((ByReferenceType) this_parameter_type).ElementType;
@@ -262,8 +268,9 @@ namespace Mono.Cecil.Tests {
 			var module = typeof (MethodBodyTests).ToDefinition ().Module;
 			var @object = module.TypeSystem.Object.Resolve ();
 			var method = @object.Methods.Where (m => m.HasBody).First ();
+			var body = method.Body.AsILMethodBody();
 
-			var type = method.Body.ThisParameter.ParameterType;
+			var type = body.ThisParameter.ParameterType;
 			Assert.IsFalse (type.IsValueType);
 			Assert.IsFalse (type.IsPrimitive);
 			Assert.IsFalse (type.IsPointer);
@@ -275,9 +282,10 @@ namespace Mono.Cecil.Tests {
 			TestIL ("hello.il", module => {
 				var type = module.GetType ("Foo");
 				var method = type.GetMethod ("TestFilter");
-
 				Assert.IsNotNull (method);
-				Assert.AreEqual (2, method.Body.MaxStackSize);
+
+				var body = method.Body.AsILMethodBody();
+				Assert.AreEqual (2, body.MaxStackSize);
 			});
 		}
 
@@ -293,7 +301,8 @@ namespace Mono.Cecil.Tests {
 				Assert.IsNotNull (method);
 				Assert.IsNotNull (method.Body);
 
-				var leave = method.Body.Instructions [0];
+				var body = method.Body.AsILMethodBody();
+				var leave = body.Instructions [0];
 				Assert.AreEqual (OpCodes.Leave, leave.OpCode);
 				Assert.IsNull (leave.Operand);
 				Assert.AreEqual ("IL_0000: leave", leave.ToString ());
@@ -317,7 +326,8 @@ namespace Mono.Cecil.Tests {
 				var get_fiou = type.GetMethod ("get_Fiou");
 				Assert.IsNotNull (get_fiou);
 
-				var ldstr = get_fiou.Body.Instructions.Where (i => i.OpCode == OpCodes.Ldstr).First ();
+				var body = get_fiou.Body.AsILMethodBody();
+				var ldstr = body.Instructions.Where (i => i.OpCode == OpCodes.Ldstr).First ();
 				Assert.AreEqual ("fiou", ldstr.Operand);
 			});
 		}

--- a/Test/Mono.Cecil.Tests/MethodTests.cs
+++ b/Test/Mono.Cecil.Tests/MethodTests.cs
@@ -157,14 +157,15 @@ namespace Mono.Cecil.Tests {
 
 				Assert.IsTrue (foo.IsVarArg ());
 
-				var foo_reference = (MethodReference) baz.Body.Instructions.First (i => i.Offset == 0x000a).Operand;
+				var bazBody = baz.Body.AsILMethodBody();
+				var foo_reference = (MethodReference) bazBody.Instructions.First (i => i.Offset == 0x000a).Operand;
 
 				Assert.IsTrue (foo_reference.IsVarArg ());
 				Assert.AreEqual (0, foo_reference.GetSentinelPosition ());
 
 				Assert.AreEqual (foo, foo_reference.Resolve ());
 
-				var bar_reference = (MethodReference) baz.Body.Instructions.First (i => i.Offset == 0x0023).Operand;
+				var bar_reference = (MethodReference) bazBody.Instructions.First (i => i.Offset == 0x0023).Operand;
 
 				Assert.IsTrue (bar_reference.IsVarArg ());
 
@@ -180,10 +181,11 @@ namespace Mono.Cecil.Tests {
 			TestCSharp ("Generics.cs", module => {
 				var type = module.GetType ("It");
 				var method = type.GetMethod ("ReadPwow");
+				var body = method.Body.AsILMethodBody();
 
 				GenericInstanceMethod instance = null;
 
-				foreach (var instruction in method.Body.Instructions) {
+				foreach (var instruction in body.Instructions) {
 					instance = instruction.Operand as GenericInstanceMethod;
 					if (instance != null)
 						break;
@@ -204,8 +206,10 @@ namespace Mono.Cecil.Tests {
 				var beta = type.GetMethod ("Beta");
 				var charlie = type.GetMethod ("Charlie");
 
-				var new_list_beta = (MethodReference) beta.Body.Instructions [0].Operand;
-				var new_list_charlie = (MethodReference) charlie.Body.Instructions [0].Operand;
+				var betaBody = beta.Body.AsILMethodBody();
+				var charlieBody = charlie.Body.AsILMethodBody();
+				var new_list_beta = (MethodReference) betaBody.Instructions [0].Operand;
+				var new_list_charlie = (MethodReference) charlieBody.Instructions [0].Operand;
 
 				Assert.AreEqual ("System.Collections.Generic.List`1<TBeta>", new_list_beta.DeclaringType.FullName);
 				Assert.AreEqual ("System.Collections.Generic.List`1<TCharlie>", new_list_charlie.DeclaringType.FullName);

--- a/Test/Mono.Cecil.Tests/PortablePdbTests.cs
+++ b/Test/Mono.Cecil.Tests/PortablePdbTests.cs
@@ -495,7 +495,9 @@ class Program
 				if (!method.HasBody)
 					continue;
 
-				foreach (var instruction in method.Body.Instructions) {
+				var body = method.Body.AsILMethodBody();
+
+				foreach (var instruction in body.Instructions) {
 					var sp = method.DebugInformation.GetSequencePoint (instruction);
 					if (sp != null && sp.Document != null)
 						return sp.Document;

--- a/Test/Mono.Cecil.Tests/ResolveTests.cs
+++ b/Test/Mono.Cecil.Tests/ResolveTests.cs
@@ -244,7 +244,8 @@ namespace Mono.Cecil.Tests {
 		{
 			Assert.IsTrue (method.HasBody);
 
-			var instruction = method.Body.Instructions [method.Body.Instructions.Count - 1];
+			var body = method.Body.AsILMethodBody();
+			var instruction = body.Instructions [body.Instructions.Count - 1];
 
 			Assert.IsNotNull (instruction);
 

--- a/Test/Mono.Cecil.Tests/TypeTests.cs
+++ b/Test/Mono.Cecil.Tests/TypeTests.cs
@@ -167,7 +167,8 @@ namespace Mono.Cecil.Tests {
 				var baz = module.GetType ("Baz");
 				var method = baz.GetMethod ("PrintAnswer");
 
-				var box = method.Body.Instructions.Where (i => i.OpCode == OpCodes.Box).First ();
+				var body = method.Body.AsILMethodBody();
+				var box = body.Instructions.Where (i => i.OpCode == OpCodes.Box).First ();
 				var int32 = (TypeReference) box.Operand;
 
 				Assert.IsTrue (int32.IsValueType);
@@ -211,7 +212,8 @@ namespace Mono.Cecil.Tests {
 				var type = module.GetType ("LaMatrix");
 				var method = type.GetMethod ("At");
 
-				var call = method.Body.Instructions.Where (i => i.Operand is MethodReference).First ();
+				var body = method.Body.AsILMethodBody();
+				var call = body.Instructions.Where (i => i.Operand is MethodReference).First ();
 				var get = (MethodReference) call.Operand;
 
 				Assert.IsNotNull (get);

--- a/symbols/pdb/Test/Mono.Cecil.Tests/PdbTests.cs
+++ b/symbols/pdb/Test/Mono.Cecil.Tests/PdbTests.cs
@@ -413,7 +413,7 @@ namespace Mono.Cecil.Tests {
 			var method = new MethodDefinition ("Pang", MethodAttributes.Public | MethodAttributes.Static, module.ImportReference (typeof (string)));
 			type.Methods.Add (method);
 
-			var body = method.Body;
+			var body = (MethodBody)method.Body;
 
 			body.InitLocals = true;
 


### PR DESCRIPTION
Hi,

This PR is just a proof-of-concept to see how difficult could be to allow different kinds of method body implementations besides the currently provided MethodBody class for IL in Cecil API and also to start a discussion about this.

The idea is to provide the user the possibility to reuse the Cecil metadata model while extending it by implementing his own representation of method bodies. This way other code representations can be used instead of CIL, allowing higher levels of abstraction. For example, Abstract Syntax Tree (AST), Three Address Code (TAC), Static Single Assignment form (SSA), etc. Is important to note that Cecil doesn't have to provide these implementations nor support them, just need to be flexible enough to allow users to do it themselves.

I just included the Method property in the IMethodBody interface to keep it simple for the moment and to avoid imposing too many members that all other implementations must provide. But I'm not entirely sure about this decision, maybe it makes sense to also include the following properties:

```csharp
bool HasVariables { get; }
Collection<VariableDefinition> Variables { get; }
ParameterDefinition ThisParameter { get; }
```

I have also extended the Mixin class to include a handy helper method AsILMethodBody to avoid having to cast manually in every location where the original (IL) MethodBody class implementation is expected.

Please let me know what do you think about this and I will be happy to update the PR with the requested changes.

Thanks,
Edgardo.