### PR TITLE
Fixed invalid format in String.Format

### DIFF
--- a/symbols/mdb/Mono.CompilerServices.SymbolWriter/MonoSymbolTable.cs
+++ b/symbols/mdb/Mono.CompilerServices.SymbolWriter/MonoSymbolTable.cs
@@ -234,7 +234,7 @@ namespace Mono.CompilerServices.SymbolWriter
 
 		public override string ToString ()
 		{
-			return String.Format ("[Line {0}:{1,2}-{3,4}:{5}]", File, Row, Column, EndRow, EndColumn, Offset);
+			return String.Format ("[Line {0}:{1},{2}-{3},{4}:{5}]", File, Row, Column, EndRow, EndColumn, Offset);
 		}
 	}
 


### PR DESCRIPTION
Found by [CodeRush for Roslyn Static Code Analysis](https://documentation.devexpress.com/CodeRushForRoslyn/118105/Code-Analysis/Analyzers-Library/CRR0007-String-format-item-argument-mismatch)
