### PR TITLE
Fix win32 resource processing.

### DIFF
--- a/Mono.Cecil.PE/Image.cs
+++ b/Mono.Cecil.PE/Image.cs
@@ -39,6 +39,7 @@ namespace Mono.Cecil.PE {
 		public uint Timestamp;
 		public ModuleAttributes Attributes;
 
+		public DataDirectory Win32Resources;
 		public DataDirectory Debug;
 		public DataDirectory Resources;
 		public DataDirectory StrongName;

--- a/Mono.Cecil.PE/ImageReader.cs
+++ b/Mono.Cecil.PE/ImageReader.cs
@@ -160,12 +160,18 @@ namespace Mono.Cecil.PE {
 
 			// ExportTable			8
 			// ImportTable			8
+
+			Advance (pe64 ? 56 : 40);
+
 			// ResourceTable		8
+
+			image.Win32Resources = ReadDataDirectory ();
+
 			// ExceptionTable		8
 			// CertificateTable		8
 			// BaseRelocationTable	8
 
-			Advance (pe64 ? 88 : 72);
+			Advance (24);
 
 			// Debug				8
 			image.Debug = ReadDataDirectory ();


### PR DESCRIPTION
The code assumed that win32 resources always lived in .rsrc section in the
input assembly. That's not always the case. For example, crossgen moves
win32 resources to the beginning of .text section.

The fix is to get the location of win32 resources from resources directory.
Win32 resources are still output to .rsrc section by the ImageWriter.