### PR TITLE
Fix reading broken MDBs emitted by mcs

### DIFF
--- a/symbols/mdb/Mono.Cecil.Mdb/MdbReader.cs
+++ b/symbols/mdb/Mono.Cecil.Mdb/MdbReader.cs
@@ -190,7 +190,7 @@ namespace Mono.Cecil.Mdb {
 			var source = symbol_file.GetSourceFile (line.File);
 			return new SequencePoint (line.Offset, GetDocument (source)) {
 				StartLine = line.Row,
-				EndLine = line.EndRow,
+				EndLine = line.EndRow != -1 ? line.EndRow : line.Row,
 				StartColumn = line.Column,
 				EndColumn = line.EndColumn,
 			};

--- a/symbols/mdb/Test/Mono.Cecil.Tests/MdbTests.cs
+++ b/symbols/mdb/Test/Mono.Cecil.Tests/MdbTests.cs
@@ -17,17 +17,17 @@ namespace Mono.Cecil.Tests {
 
 				AssertCode (@"
 	.locals init (System.Int32 i)
-	.line 6,-1:-1,-1 'C:\sources\cecil\symbols\Mono.Cecil.Mdb\Test\Resources\assemblies\hello.cs'
+	.line 6,6:-1,-1 'C:\sources\cecil\symbols\Mono.Cecil.Mdb\Test\Resources\assemblies\hello.cs'
 	IL_0000: ldc.i4.0
 	IL_0001: stloc.0
-	.line 7,-1:-1,-1 'C:\sources\cecil\symbols\Mono.Cecil.Mdb\Test\Resources\assemblies\hello.cs'
+	.line 7,7:-1,-1 'C:\sources\cecil\symbols\Mono.Cecil.Mdb\Test\Resources\assemblies\hello.cs'
 	IL_0002: br IL_0013
-	.line 8,-1:-1,-1 'C:\sources\cecil\symbols\Mono.Cecil.Mdb\Test\Resources\assemblies\hello.cs'
+	.line 8,8:-1,-1 'C:\sources\cecil\symbols\Mono.Cecil.Mdb\Test\Resources\assemblies\hello.cs'
 	IL_0007: ldarg.0
 	IL_0008: ldloc.0
 	IL_0009: ldelem.ref
 	IL_000a: call System.Void Program::Print(System.String)
-	.line 7,-1:-1,-1 'C:\sources\cecil\symbols\Mono.Cecil.Mdb\Test\Resources\assemblies\hello.cs'
+	.line 7,7:-1,-1 'C:\sources\cecil\symbols\Mono.Cecil.Mdb\Test\Resources\assemblies\hello.cs'
 	IL_000f: ldloc.0
 	IL_0010: ldc.i4.1
 	IL_0011: add
@@ -37,7 +37,7 @@ namespace Mono.Cecil.Tests {
 	IL_0015: ldlen
 	IL_0016: conv.i4
 	IL_0017: blt IL_0007
-	.line 10,-1:-1,-1 'C:\sources\cecil\symbols\Mono.Cecil.Mdb\Test\Resources\assemblies\hello.cs'
+	.line 10,10:-1,-1 'C:\sources\cecil\symbols\Mono.Cecil.Mdb\Test\Resources\assemblies\hello.cs'
 	IL_001c: ldc.i4.0
 	IL_001d: ret
 ", main);


### PR DESCRIPTION
If sequence point ends at row -1, assume that the sequence point is just for a single line. This fixes Unity case 953154.

Related PR in Unity fork: https://github.com/Unity-Technologies/cecil/pull/17