### PR TITLE
Add constructor arguments to ICustomAttribute.

### DIFF
--- a/Mono.Cecil/CustomAttribute.cs
+++ b/Mono.Cecil/CustomAttribute.cs
@@ -62,8 +62,10 @@ namespace Mono.Cecil {
 
 		bool HasFields { get; }
 		bool HasProperties { get; }
+		bool HasConstructorArguments { get; }
 		Collection<CustomAttributeNamedArgument> Fields { get; }
 		Collection<CustomAttributeNamedArgument> Properties { get; }
+		Collection<CustomAttributeArgument> ConstructorArguments { get; }
 	}
 
 	public sealed class CustomAttribute : ICustomAttribute {

--- a/Mono.Cecil/SecurityDeclaration.cs
+++ b/Mono.Cecil/SecurityDeclaration.cs
@@ -70,6 +70,14 @@ namespace Mono.Cecil {
 		{
 			this.attribute_type = attributeType;
 		}
+
+		bool ICustomAttribute.HasConstructorArguments {
+			get { return false; }
+		}
+
+		Collection<CustomAttributeArgument> ICustomAttribute.ConstructorArguments {
+			get { return new Collection<CustomAttributeArgument> (); }
+		}
 	}
 
 	public sealed class SecurityDeclaration {

--- a/Mono.Cecil/SecurityDeclaration.cs
+++ b/Mono.Cecil/SecurityDeclaration.cs
@@ -76,7 +76,7 @@ namespace Mono.Cecil {
 		}
 
 		Collection<CustomAttributeArgument> ICustomAttribute.ConstructorArguments {
-			get { return new Collection<CustomAttributeArgument> (); }
+			get { throw new NotSupportedException (); }
 		}
 	}
 


### PR DESCRIPTION
My use case is to write methods that:

* Processes constructor arguments in custom attributes.
* Accepts CustomAttribute instances
* Accepts a custom class of attributes

Adding constructor arguments to ICustomAttribute makes this possible by making
these methods take an ICustomAttribute, and have my custom class of attributes
implement ICustomAttribute.