### PR TITLE
Support for cross-TFM type import in `DefaultReflectionImporter`

### DIFF
--- a/Mono.Cecil/Import.cs
+++ b/Mono.Cecil/Import.cs
@@ -177,7 +177,7 @@ namespace Mono.Cecil {
 				string.Empty,
 				type.Name,
 				module,
-				ImportScope (type.Assembly ()),
+				ImportReference (GetAssemblyNameForImport (type)),
 				type.IsValueType ());
 
 			reference.etype = ImportElementType (type);
@@ -294,9 +294,9 @@ namespace Mono.Cecil {
 			return etype;
 		}
 
-		AssemblyNameReference ImportScope (SR.Assembly assembly)
+		protected virtual SR.AssemblyName GetAssemblyNameForImport (Type type)
 		{
-			return ImportReference (assembly.GetName ());
+			return type.Assembly ().GetName ();
 		}
 
 		public virtual AssemblyNameReference ImportReference (SR.AssemblyName name)


### PR DESCRIPTION
I have been using Cecil for cross-TFM assembly modification (e.g. `net45` process editing `netcore2.0` assemblies). To enable smooth importing of types across TFMs, where semantically identical types can live in different assemblies, I substitute a customized `IReflectionImporter`. This works well, but unfortunately the key method `AssemblyNameReference DefaultReflectionImporter.ImportScope (SR.Assembly assembly)` does not provide access to the type for which the scope is being imported. I am forced to copy the whole code of `DefaultReflectionImporter` (with `ImportGenericContext`) and modify it, something which I'd like to avoid. I suggest a small refactoring that would help users with similar needs, keep existing functionality exactly as it is, and have minimal-to-no impact on existing code bases:
```
diff --git a/Mono.Cecil/Import.cs b/Mono.Cecil/Import.cs
index 4bf10cc..3683c93 100644
--- a/Mono.Cecil/Import.cs
+++ b/Mono.Cecil/Import.cs
@@ -177,5 +177,5 @@ namespace Mono.Cecil {
 				string.Empty,
 				type.Name,
 				module,
-				ImportScope (type.Assembly ()),
+				ImportScope (type),
 				type.IsValueType ());
@@ -297,6 +297,6 @@ namespace Mono.Cecil {
-		AssemblyNameReference ImportScope (SR.Assembly assembly)
+		protected virtual AssemblyNameReference ImportScope (Type type)
 		{
-			return ImportReference (assembly.GetName ());
+			return ImportReference (type.Assembly ().GetName ());
 		}
 
 		public virtual AssemblyNameReference ImportReference (SR.AssemblyName name)
```