### PR TITLE
Add ILLibrary ModuleAttribute

### DIFF
--- a/Mono.Cecil/ModuleKind.cs
+++ b/Mono.Cecil/ModuleKind.cs
@@ -38,6 +38,7 @@ namespace Mono.Cecil {
 	public enum ModuleAttributes {
 		ILOnly = 1,
 		Required32Bit = 2,
+		ILLibrary = 4,
 		StrongNameSigned = 8,
 		Preferred32Bit = 0x00020000,
 	}


### PR DESCRIPTION
This is used for R2R assemblies. This flag will be used by the linker to detect R2R assemblies, as we do here: https://github.com/mono/linker/pull/99.

We had discussed making cecil aware of R2R assemblies in https://github.com/jbevain/cecil/issues/390, but decided to put that logic in the linker. I think it's reasonable to at least add this enum value to cecil so that the linker can use it.

/cc @erozenfeld 