### PR TITLE
Add support for Mono 4.4 API directories

### DIFF
--- a/Mono.Cecil/BaseAssemblyResolver.cs
+++ b/Mono.Cecil/BaseAssemblyResolver.cs
@@ -281,6 +281,13 @@ namespace Mono.Cecil {
 			var file = Path.Combine (path, "mscorlib.dll");
 			if (File.Exists (file))
 				return GetAssembly (file, parameters);
+			else if (on_mono && Directory.Exists(path + "-api"))
+			{
+				path = path + "-api";
+				file = Path.Combine (path, "mscorlib.dll");
+				if (File.Exists (file))
+					return GetAssembly (file, parameters);
+			}
 
 			return null;
 		}


### PR DESCRIPTION
Mono 4.4 added "reference assemblies". When resolving mscorlib we
should check for these reference assemblies at the asked for version.
Without this check mscorlib on linux will always resolve to a 4.0
assembly even if the AssemblyNameReference was for version 2.0 or 3.0.

See http://www.mono-project.com/docs/about-mono/releases/4.4.0/

Fixes opentk/opentk/issues/642