### PR TITLE
Add [DebuggerDisplay] to CustomAttribute and SecurityAttribute

### DIFF
--- a/Mono.Cecil/CustomAttribute.cs
+++ b/Mono.Cecil/CustomAttribute.cs
@@ -9,7 +9,7 @@
 //
 
 using System;
-
+using System.Diagnostics;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -66,6 +66,7 @@ namespace Mono.Cecil {
 		Collection<CustomAttributeNamedArgument> Properties { get; }
 	}
 
+	[DebuggerDisplay ("{AttributeType}")]
 	public sealed class CustomAttribute : ICustomAttribute {
 
 		internal CustomAttributeValueProjection projection;

--- a/Mono.Cecil/SecurityDeclaration.cs
+++ b/Mono.Cecil/SecurityDeclaration.cs
@@ -9,7 +9,7 @@
 //
 
 using System;
-
+using System.Diagnostics;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -38,6 +38,7 @@ namespace Mono.Cecil {
 		Collection<SecurityDeclaration> SecurityDeclarations { get; }
 	}
 
+	[DebuggerDisplay ("{AttributeType}")]
 	public sealed class SecurityAttribute : ICustomAttribute {
 
 		TypeReference attribute_type;


### PR DESCRIPTION
When viewing CustomAttributes and SecurityAttributes collection properties on various classes in a watch window, it's tedious to find the element with the attribute type you are interested in.  Displaying the AttributeType in the debugger helps make this much easier