### PR TITLE
Develop/issue 485

### DIFF
--- a/Mono.Cecil.PE/Image.cs
+++ b/Mono.Cecil.PE/Image.cs
@@ -28,7 +28,7 @@ namespace Mono.Cecil.PE {
 		public string RuntimeVersion;
 		public TargetArchitecture Architecture;
 		public ModuleCharacteristics Characteristics;
-		public ushort Linker;
+		public ushort LinkerVersion;
 
 		public ImageDebugHeader DebugHeader;
 
@@ -59,7 +59,6 @@ namespace Mono.Cecil.PE {
 		public Image ()
 		{
 			counter = GetTableLength;
-			Linker = 0;
 		}
 
 		public bool HasTable (Table table)

--- a/Mono.Cecil.PE/Image.cs
+++ b/Mono.Cecil.PE/Image.cs
@@ -28,6 +28,7 @@ namespace Mono.Cecil.PE {
 		public string RuntimeVersion;
 		public TargetArchitecture Architecture;
 		public ModuleCharacteristics Characteristics;
+		public ushort Linker;
 
 		public ImageDebugHeader DebugHeader;
 
@@ -58,6 +59,7 @@ namespace Mono.Cecil.PE {
 		public Image ()
 		{
 			counter = GetTableLength;
+			Linker = 0;
 		}
 
 		public bool HasTable (Table table)

--- a/Mono.Cecil.PE/ImageReader.cs
+++ b/Mono.Cecil.PE/ImageReader.cs
@@ -81,8 +81,8 @@ namespace Mono.Cecil.PE {
 			// Characteristics		2
 			ushort characteristics = ReadUInt16 ();
 
-			ushort subsystem, dll_characteristics, linker;
-			ReadOptionalHeaders (out subsystem, out dll_characteristics, out linker);
+			ushort subsystem, dll_characteristics, linker_version;
+			ReadOptionalHeaders (out subsystem, out dll_characteristics, out linker_version);
 			ReadSections (sections);
 			ReadCLIHeader ();
 			ReadMetadata ();
@@ -90,7 +90,7 @@ namespace Mono.Cecil.PE {
 
 			image.Kind = GetModuleKind (characteristics, subsystem);
 			image.Characteristics = (ModuleCharacteristics) dll_characteristics;
-			image.Linker = linker;
+			image.LinkerVersion = linker_version;
 		}
 
 		TargetArchitecture ReadArchitecture ()

--- a/Mono.Cecil.PE/ImageReader.cs
+++ b/Mono.Cecil.PE/ImageReader.cs
@@ -81,8 +81,8 @@ namespace Mono.Cecil.PE {
 			// Characteristics		2
 			ushort characteristics = ReadUInt16 ();
 
-			ushort subsystem, dll_characteristics;
-			ReadOptionalHeaders (out subsystem, out dll_characteristics);
+			ushort subsystem, dll_characteristics, linker;
+			ReadOptionalHeaders (out subsystem, out dll_characteristics, out linker);
 			ReadSections (sections);
 			ReadCLIHeader ();
 			ReadMetadata ();
@@ -90,6 +90,7 @@ namespace Mono.Cecil.PE {
 
 			image.Kind = GetModuleKind (characteristics, subsystem);
 			image.Characteristics = (ModuleCharacteristics) dll_characteristics;
+			image.Linker = linker;
 		}
 
 		TargetArchitecture ReadArchitecture ()
@@ -108,7 +109,7 @@ namespace Mono.Cecil.PE {
 			return ModuleKind.Console;
 		}
 
-		void ReadOptionalHeaders (out ushort subsystem, out ushort dll_characteristics)
+		void ReadOptionalHeaders (out ushort subsystem, out ushort dll_characteristics, out ushort linker)
 		{
 			// - PEOptionalHeader
 			//   - StandardFieldsHeader
@@ -118,8 +119,7 @@ namespace Mono.Cecil.PE {
 
 			//						pe32 || pe64
 
-			// LMajor				1
-			// LMinor				1
+			linker = ReadUInt16 ();
 			// CodeSize				4
 			// InitializedDataSize	4
 			// UninitializedDataSize4
@@ -142,7 +142,7 @@ namespace Mono.Cecil.PE {
 			// ImageSize			4
 			// HeaderSize			4
 			// FileChecksum			4
-			Advance (66);
+			Advance (64);
 
 			// SubSystem			2
 			subsystem = ReadUInt16 ();

--- a/Mono.Cecil.PE/ImageWriter.cs
+++ b/Mono.Cecil.PE/ImageWriter.cs
@@ -219,7 +219,7 @@ namespace Mono.Cecil.PE {
 		void WriteOptionalHeaders ()
 		{
 			WriteUInt16 ((ushort) (!pe64 ? 0x10b : 0x20b)); // Magic
-			WriteUInt16 (module.Linker);
+			WriteUInt16 (module.linker_version);
 			WriteUInt32 (text.SizeOfRawData);	// CodeSize
 			WriteUInt32 ((reloc != null ? reloc.SizeOfRawData : 0)
 				+ (rsrc != null ? rsrc.SizeOfRawData : 0));	// InitializedDataSize

--- a/Mono.Cecil.PE/ImageWriter.cs
+++ b/Mono.Cecil.PE/ImageWriter.cs
@@ -218,9 +218,8 @@ namespace Mono.Cecil.PE {
 
 		void WriteOptionalHeaders ()
 		{
-			WriteUInt16 ((ushort) (!pe64 ? 0x10b : 0x20b));	// Magic
-			WriteByte (0);	// LMajor
-			WriteByte (0);	// LMinor
+			WriteUInt16 ((ushort) (!pe64 ? 0x10b : 0x20b)); // Magic
+			WriteUInt16 (module.Linker);
 			WriteUInt32 (text.SizeOfRawData);	// CodeSize
 			WriteUInt32 ((reloc != null ? reloc.SizeOfRawData : 0)
 				+ (rsrc != null ? rsrc.SizeOfRawData : 0));	// InitializedDataSize

--- a/Mono.Cecil.PE/ImageWriter.cs
+++ b/Mono.Cecil.PE/ImageWriter.cs
@@ -219,7 +219,7 @@ namespace Mono.Cecil.PE {
 		void WriteOptionalHeaders ()
 		{
 			WriteUInt16 ((ushort) (!pe64 ? 0x10b : 0x20b));	// Magic
-			WriteByte (8);	// LMajor
+			WriteByte (0);	// LMajor
 			WriteByte (0);	// LMinor
 			WriteUInt32 (text.SizeOfRawData);	// CodeSize
 			WriteUInt32 ((reloc != null ? reloc.SizeOfRawData : 0)

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -240,6 +240,8 @@ namespace Mono.Cecil {
 
 	public sealed class ModuleDefinition : ModuleReference, ICustomAttributeProvider, ICustomDebugInformationProvider, IDisposable {
 
+		private static ushort defaultLinkerValue = 0; // or 8 to retain previous default behaviour
+
 		internal Image Image;
 		internal MetadataSystem MetadataSystem;
 		internal ReadingMode ReadingMode;
@@ -260,6 +262,7 @@ namespace Mono.Cecil {
 		TargetArchitecture architecture;
 		ModuleAttributes attributes;
 		ModuleCharacteristics characteristics;
+		ushort linker;
 		Guid mvid;
 		internal uint timestamp;
 
@@ -333,7 +336,12 @@ namespace Mono.Cecil {
 			set { characteristics = value; }
 		}
 
-		[Obsolete("Use FileName")]
+		public ushort Linker {
+			get { return linker; }
+			set { linker = value; }
+		}
+
+		[Obsolete ("Use FileName")]
 		public string FullyQualifiedName {
 			get { return file_name; }
 		}
@@ -567,6 +575,7 @@ namespace Mono.Cecil {
 		{
 			this.MetadataSystem = new MetadataSystem ();
 			this.token = new MetadataToken (TokenType.Module, 1);
+			this.linker = defaultLinkerValue;
 		}
 
 		internal ModuleDefinition (Image image)
@@ -578,6 +587,7 @@ namespace Mono.Cecil {
 			this.architecture = image.Architecture;
 			this.attributes = image.Attributes;
 			this.characteristics = image.Characteristics;
+			this.linker = image.Linker;
 			this.file_name = image.FileName;
 			this.timestamp = image.Timestamp;
 

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -240,8 +240,6 @@ namespace Mono.Cecil {
 
 	public sealed class ModuleDefinition : ModuleReference, ICustomAttributeProvider, ICustomDebugInformationProvider, IDisposable {
 
-		private static ushort defaultLinkerValue = 0; // or 8 to retain previous default behaviour
-
 		internal Image Image;
 		internal MetadataSystem MetadataSystem;
 		internal ReadingMode ReadingMode;
@@ -262,7 +260,7 @@ namespace Mono.Cecil {
 		TargetArchitecture architecture;
 		ModuleAttributes attributes;
 		ModuleCharacteristics characteristics;
-		ushort linker;
+		internal ushort linker_version = 8;
 		Guid mvid;
 		internal uint timestamp;
 
@@ -334,11 +332,6 @@ namespace Mono.Cecil {
 		public ModuleCharacteristics Characteristics {
 			get { return characteristics; }
 			set { characteristics = value; }
-		}
-
-		public ushort Linker {
-			get { return linker; }
-			set { linker = value; }
 		}
 
 		[Obsolete ("Use FileName")]
@@ -575,7 +568,6 @@ namespace Mono.Cecil {
 		{
 			this.MetadataSystem = new MetadataSystem ();
 			this.token = new MetadataToken (TokenType.Module, 1);
-			this.linker = defaultLinkerValue;
 		}
 
 		internal ModuleDefinition (Image image)
@@ -587,7 +579,7 @@ namespace Mono.Cecil {
 			this.architecture = image.Architecture;
 			this.attributes = image.Attributes;
 			this.characteristics = image.Characteristics;
-			this.linker = image.Linker;
+			this.linker_version = image.LinkerVersion;
 			this.file_name = image.FileName;
 			this.timestamp = image.Timestamp;
 


### PR DESCRIPTION
This is as much a straw-man proposal as anything, exposing the linker version as a ushort, rather than trying to assembly a full history of possible linker versions as an enum (C++/CLI uses non-zero minor versions -- currently VS2017 v15.5.5 gives 14.12 --  and I'm not sure I can catch them all).

Watching in the debugger while the unit tests ran, we have everything from linker version 6 (a very early .net version indeed) through to 80 (VB Roslyn) coming through to the image writer, so the changes have been put through their paces.