### PR TITLE
null debug_info with body

### DIFF
--- a/Mono.Cecil/MethodDefinition.cs
+++ b/Mono.Cecil/MethodDefinition.cs
@@ -165,6 +165,8 @@ namespace Mono.Cecil {
 				// we reset Body to null in ILSpy to save memory; so we need that operation to be thread-safe
 				lock (module.SyncRoot) {
 					body = value;
+					if (value == null)
+						this.debug_info = null;
 				}
 			}
 		}


### PR DESCRIPTION
debug_info is intimately related to the body.
If the body is set to null then the debug_info should also be set to null.

**Notes:**
* The debug_info can be large and so memory savings from discarding the body cannot be fully realized unless the debug_info is also discarded.
* debug_info is automatically built when the body is created. If a debug_info already exists, then an InvalidOperationException is raised from deep within the build process...