### PR TITLE
Expose relative size of  module metadata

### DIFF
--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -280,6 +280,10 @@ namespace Mono.Cecil {
 
 		internal Collection<CustomDebugInformation> custom_infos;
 
+		public uint RelativeSize {
+			get { return Image.MetadataSection.SizeOfRawData; }
+		}
+
 		public bool IsMain {
 			get { return kind != ModuleKind.NetModule; }
 		}


### PR DESCRIPTION
Expose the raw size of a module's metadata to allow load balancing of searches over large number of assemblies. The raw size of the metadata is a reasonable indicator of the relative amount of work required to search an assembly.