### PR TITLE
Add a ClassLayoutTable row for structs with no instance fields

### DIFF
--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1441,6 +1441,25 @@ namespace Mono.Cecil {
 
 			if (type.HasLayoutInfo)
 				AddLayoutInfo (type);
+			else
+			if (type.IsValueType)
+			{
+				var no_instance_fields = !type.HasFields;
+				if (!no_instance_fields)
+				{
+					var fields = type.Fields;
+
+					for (int i = 0; i < fields.Count; i++)
+						if (!fields [i].IsStatic)
+						{
+							no_instance_fields = false;
+							break;
+						}
+				}
+
+				if (no_instance_fields)
+					GetTable<ClassLayoutTable> (Table.ClassLayout).AddRow (new ClassLayoutRow (0, 1, type.token.RID));
+			}
 
 			if (type.HasFields)
 				AddFields (type);

--- a/Test/Mono.Cecil.Tests/TypeTests.cs
+++ b/Test/Mono.Cecil.Tests/TypeTests.cs
@@ -31,6 +31,19 @@ namespace Mono.Cecil.Tests {
 		}
 
 		[Test]
+		public void EmptyStructLayout ()
+		{
+			TestModule ("hello.exe", module =>
+			{
+				var foo = new TypeDefinition ("", "Foo",
+					TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit | TypeAttributes.SequentialLayout,
+					module.ImportReference (typeof (ValueType))) ;
+
+				module.Types.Add (foo) ;
+			}) ;
+		}
+
+		[Test]
 		public void SimpleInterfaces ()
 		{
 			TestIL ("types.il", module => {


### PR DESCRIPTION
Value types with no instance fields must specify a class size of 1 to be verifiable.