### PR TITLE
Out-of-range rids emitted in metadata tables

### DIFF
--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1327,8 +1327,14 @@ namespace Mono.Cecil {
 			if (type == null)
 				return MetadataToken.Zero;
 
-			if (type.IsDefinition)
-				return type.token;
+			for (var temp = type; ; temp = temp.DeclaringType)
+			{
+				if (temp.IsDefinition)
+					return type.CheckedResolve ().token;
+
+				if (temp.IsTypeSpecification () || !temp.IsNested)
+					break;
+			}
 
 			if (type.IsTypeSpecification ())
 				return GetTypeSpecToken (type);

--- a/Test/Mono.Cecil.Tests/NestedTypesTests.cs
+++ b/Test/Mono.Cecil.Tests/NestedTypesTests.cs
@@ -21,6 +21,7 @@ namespace Mono.Cecil.Tests {
 					module.ImportReference (typeof (void)));
 
 				bingo.Methods.Add (method);
+				method.Body.InitLocals = true;
 
 				var il = method.Body.GetILProcessor ();
 				var tr = new TypeReference (null, fuel.Name, module, null)

--- a/Test/Mono.Cecil.Tests/NestedTypesTests.cs
+++ b/Test/Mono.Cecil.Tests/NestedTypesTests.cs
@@ -10,6 +10,30 @@ namespace Mono.Cecil.Tests {
 	public class NestedTypesTests : BaseTestFixture {
 
 		[Test]
+		public void NestedTypeRefs ()
+		{
+			TestCSharp ("NestedTypes.cs", module => {
+				var bingo = module.GetType ("Bingo");
+				var fuel = bingo.NestedTypes [0];
+
+				var method = new MethodDefinition ("test",
+					MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static,
+					module.ImportReference (typeof (void)));
+
+				bingo.Methods.Add (method);
+
+				var il = method.Body.GetILProcessor ();
+				var tr = new TypeReference (null, fuel.Name, module, null)
+				{
+					DeclaringType = bingo
+				};
+
+				il.Body.Variables.Add (new Cil.VariableDefinition (tr));
+				il.Emit (Cil.OpCodes.Ret);
+			});
+		}
+
+		[Test]
 		public void NestedTypes ()
 		{
 			TestCSharp ("NestedTypes.cs", module => {


### PR DESCRIPTION
...if a `TypeReference` to a nested type is created with `DeclaredType` set to a `TypeDefinition`. This behavior is unexpected because `TypeDefinition` inherits from `TypeReference` and is usually usable where a `TypeReference` is required. Context: it is sometimes easier to create a `TypeReference` to a nested type that will be created later.

[MWE.zip](https://github.com/jbevain/cecil/files/1837320/MWE.zip)
