### PR TITLE
Add support for delay-signing with a public only keyfile

### DIFF
--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -109,7 +109,10 @@ namespace Mono.Cecil {
 				module.Attributes |= ModuleAttributes.StrongNameSigned;
 			}
 
-			if( parameters.PublicKeyBytes != null && name != null ) {
+			if (parameters.PublicKeyBytes != null && name != null) {
+				if (parameters.StrongNameKeyPair != null)
+					throw new ArgumentException ("Provide either the public key bytes or the strong name key pair, not both.");
+
 				// Delay signing with a public-only key is possible. We only need to assign the
 				// public key to the assembly name and we should not actually sign the assembly.
 				name.PublicKey = parameters.PublicKeyBytes;

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -108,6 +108,12 @@ namespace Mono.Cecil {
 				name.PublicKey = parameters.StrongNameKeyPair.PublicKey;
 				module.Attributes |= ModuleAttributes.StrongNameSigned;
 			}
+
+			if( parameters.PublicKeyBytes != null && name != null ) {
+				// Delay signing with a public-only key is possible. We only need to assign the
+				// public key to the assembly name and we should not actually sign the assembly.
+				name.PublicKey = parameters.PublicKeyBytes;
+			}
 #endif
 
 			using (var symbol_writer = GetSymbolWriter (module, fq_name, symbol_writer_provider, parameters)) {

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -213,6 +213,7 @@ namespace Mono.Cecil {
 		bool write_symbols;
 #if !NET_CORE
 		SR.StrongNameKeyPair key_pair;
+		byte [] public_key_bytes;
 #endif
 
 		public uint? Timestamp {
@@ -239,6 +240,11 @@ namespace Mono.Cecil {
 		public SR.StrongNameKeyPair StrongNameKeyPair {
 			get { return key_pair; }
 			set { key_pair = value; }
+		}
+
+		public byte [] PublicKeyBytes {
+			get { return public_key_bytes; }
+			set { public_key_bytes = value; }
 		}
 #endif
 	}


### PR DESCRIPTION
Problem:
Mono.Cecil attempts to strong sign an assembly with a StrongNameKeyPair that only contains a public key. This throws an exception as a private key is required to complete the sign. However, it should be supported to place the public key into the AssemblyName without signing the assembly.

Fix:
Allow clients to pass in the public key.  Clients should determine if they have a proper StrongNameKeyPair that includes the private key.  If not, pass along the keyfile to be used as the public key.  In the case of using the public key bytes, do not attempt to sign the assembly and do not mark it as signed.