### PR TITLE
Fully qualified name for mscorlib was not properly serialized in attribute metadata

### DIFF
--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -3156,7 +3156,7 @@ namespace Mono.Cecil {
 
 		void WriteTypeReference (TypeReference type)
 		{
-			WriteUTF8String (TypeParser.ToParseable (type));
+			WriteUTF8String (TypeParser.ToParseable (type, top_level: false));
 		}
 
 		public void WriteMarshalInfo (MarshalInfo marshal_info)

--- a/Mono.Cecil/TypeParser.cs
+++ b/Mono.Cecil/TypeParser.cs
@@ -402,13 +402,13 @@ namespace Mono.Cecil {
 			return false;
 		}
 
-		public static string ToParseable (TypeReference type)
+		public static string ToParseable (TypeReference type, bool top_level = true)
 		{
 			if (type == null)
 				return null;
 
 			var name = new StringBuilder ();
-			AppendType (type, name, true, true);
+			AppendType (type, name, true, top_level);
 			return name.ToString ();
 		}
 


### PR DESCRIPTION
Easy to verify:

Compile a project with:
```
struct Test
{
    public fixed char Name[24];
}
```

IL gives this:
```
.field private valuetype Test/'<Name>e__FixedBuffer0' Name
.custom instance void [mscorlib]System.Runtime.CompilerServices.FixedBufferAttribute::.ctor(class [mscorlib]System.Type, int32) = (
	01 00 58 53 79 73 74 65 6d 2e 43 68 61 72 2c 20
	6d 73 63 6f 72 6c 69 62 2c 20 56 65 72 73 69 6f
	6e 3d 32 2e 30 2e 30 2e 30 2c 20 43 75 6c 74 75
	72 65 3d 6e 65 75 74 72 61 6c 2c 20 50 75 62 6c
	69 63 4b 65 79 54 6f 6b 65 6e 3d 62 37 37 61 35
	63 35 36 31 39 33 34 65 30 38 39 1e 00 00 00 00 00
)
```

This hexadecimal string decoded is:
`XSystem.Char, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089`

However, Mono.Cecil saves it as unqualified (only `System.Char`) because it's mscorlib. Removing mscorlib fully qualified name still applies in all other cases when serializating, but shouldn't be used in this specific case.