### PR TITLE
Use the 1.0 embedded PDB version

### DIFF
--- a/Mono.Cecil.Cil/PortablePdb.cs
+++ b/Mono.Cecil.Cil/PortablePdb.cs
@@ -450,6 +450,8 @@ namespace Mono.Cecil.Cil {
 
 			var directory = new ImageDebugDirectory {
 				Type = ImageDebugType.EmbeddedPortablePdb,
+				MajorVersion = 0x0100,
+				MinorVersion = 0x0100,
 			};
 
 			var data = new MemoryStream ();

--- a/Test/Mono.Cecil.Tests/PortablePdbTests.cs
+++ b/Test/Mono.Cecil.Tests/PortablePdbTests.cs
@@ -364,6 +364,8 @@ namespace Mono.Cecil.Tests {
 
 				var eppdb = header.Entries [1];
 				Assert.AreEqual (ImageDebugType.EmbeddedPortablePdb, eppdb.Directory.Type);
+				Assert.AreEqual (0x0100, eppdb.Directory.MajorVersion);
+				Assert.AreEqual (0x0100, eppdb.Directory.MinorVersion);
 			}, symbolReaderProvider: typeof (EmbeddedPortablePdbReaderProvider), symbolWriterProvider: typeof (EmbeddedPortablePdbWriterProvider));
 		}
 


### PR DESCRIPTION
This sets the embedded PDB debug directory version to be consistent with what Roslyn emits and what System.Reflection.Metadata expects, as documented [here](https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PE-COFF.md). 

Currently, using System.Reflection.Metadata to read embedded debug info produced by Cecil throws. The relevant check is [here](https://github.com/dotnet/corefx/blob/52121c8d0376dcb0f69570e793b6d40232ccabf9/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.EmbeddedPortablePdb.cs#L52-L70).


