### PR TITLE
Added additional `ResolutionException` overload

### DIFF
--- a/Mono.Cecil/MetadataResolver.cs
+++ b/Mono.Cecil/MetadataResolver.cs
@@ -54,7 +54,16 @@ namespace Mono.Cecil {
 			: base ("Failed to resolve " + member.FullName)
 		{
 			if (member == null)
-				throw new ArgumentNullException ("member");
+				throw new ArgumentNullException (nameof (member));
+
+			this.member = member;
+		}
+
+		public ResolutionException (MemberReference member, Exception innerException)
+			: base ("Failed to resolve " + member.FullName, innerException)
+		{
+			if (member == null)
+				throw new ArgumentNullException (nameof (member));
 
 			this.member = member;
 		}

--- a/Mono.Cecil/MetadataResolver.cs
+++ b/Mono.Cecil/MetadataResolver.cs
@@ -54,7 +54,7 @@ namespace Mono.Cecil {
 			: base ("Failed to resolve " + member.FullName)
 		{
 			if (member == null)
-				throw new ArgumentNullException (nameof (member));
+				throw new ArgumentNullException ("member");
 
 			this.member = member;
 		}
@@ -63,7 +63,7 @@ namespace Mono.Cecil {
 			: base ("Failed to resolve " + member.FullName, innerException)
 		{
 			if (member == null)
-				throw new ArgumentNullException (nameof (member));
+				throw new ArgumentNullException ("member");
 
 			this.member = member;
 		}


### PR DESCRIPTION
Allowing code to include the inner exception can add important context when there's an issue resolving ... particularly with custom resolvers.