### PR TITLE
Port Mono.Cecil to .NET Standard 2.0.

### DIFF
--- a/Mono.Cecil.nuspec
+++ b/Mono.Cecil.nuspec
@@ -16,7 +16,7 @@
     <dependencies>
       <group targetFramework=".NETFramework3.5" />
       <group targetFramework=".NETFramework4.0" />
-      <group targetFramework=".NETStandard1.3">
+      <group targetFramework=".NETStandard2.0">
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.IO.FileSystem" version="4.0.1" />
         <dependency id="System.IO.FileSystem.Primitives" version="4.0.1" />
@@ -31,6 +31,6 @@
   <files>
     <file src="bin\net_3_5_Release\*.dll" target="lib/net35" />
     <file src="bin\net_4_0_Release\*.dll" target="lib/net40" />
-    <file src="bin\netstandard_Release\netstandard1.3\*.dll" target="lib/netstandard1.3" />
+    <file src="bin\netstandard_Release\netstandard2.0\*.dll" target="lib/netstandard2.0" />
   </files>
 </package>

--- a/Mono.Cecil.props
+++ b/Mono.Cecil.props
@@ -49,7 +49,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="$(NetStandard)">
     <TargetFramework Condition="$(IsTestProject)">netcoreapp2.0</TargetFramework>
-    <TargetFramework Condition="!$(IsTestProject)">netstandard1.3</TargetFramework>
+    <TargetFramework Condition="!$(IsTestProject)">netstandard2.0</TargetFramework>
   </PropertyGroup>
   <Import Project="NetStandard.props" Condition="$(NetStandard)" />
   <!-- Shared References -->

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -103,12 +103,10 @@ namespace Mono.Cecil {
 			if (symbol_writer_provider == null && parameters.WriteSymbols)
 				symbol_writer_provider = new DefaultSymbolWriterProvider ();
 
-#if !NET_CORE
 			if (parameters.StrongNameKeyPair != null && name != null) {
 				name.PublicKey = parameters.StrongNameKeyPair.PublicKey;
 				module.Attributes |= ModuleAttributes.StrongNameSigned;
 			}
-#endif
 
 			using (var symbol_writer = GetSymbolWriter (module, fq_name, symbol_writer_provider, parameters)) {
 				var metadata = new MetadataBuilder (module, fq_name, timestamp, symbol_writer_provider, symbol_writer);
@@ -118,10 +116,8 @@ namespace Mono.Cecil {
 				stream.value.SetLength (0);
 				writer.WriteImage ();
 
-#if !NET_CORE
 				if (parameters.StrongNameKeyPair != null)
 					CryptoService.StrongName (stream.value, writer, parameters.StrongNameKeyPair);
-#endif
 			}
 		}
 

--- a/Mono.Cecil/BaseAssemblyResolver.cs
+++ b/Mono.Cecil/BaseAssemblyResolver.cs
@@ -76,9 +76,8 @@ namespace Mono.Cecil {
 		// Maps file names of available trusted platform assemblies to their full paths.
 		// Internal for testing.
 		internal static readonly Lazy<Dictionary<string, string>> TrustedPlatformAssemblies = new Lazy<Dictionary<string, string>> (CreateTrustedPlatformAssemblyMap);
-#else
-		Collection<string> gac_paths;
 #endif
+		Collection<string> gac_paths;
 
 		public void AddSearchDirectory (string directory)
 		{
@@ -137,7 +136,7 @@ namespace Mono.Cecil {
 			assembly = SearchTrustedPlatformAssemblies (name, parameters);
 			if (assembly != null)
 				return assembly;
-#else
+#endif
 			var framework_dir = Path.GetDirectoryName (typeof (object).Module.FullyQualifiedName);
 			var framework_dirs = on_mono
 				? new [] { framework_dir, Path.Combine (framework_dir, "Facades") }
@@ -162,7 +161,6 @@ namespace Mono.Cecil {
 			assembly = SearchDirectory (name, framework_dirs, parameters);
 			if (assembly != null)
 				return assembly;
-#endif
 			if (ResolveFailure != null) {
 				assembly = ResolveFailure (this, name);
 				if (assembly != null)
@@ -234,7 +232,6 @@ namespace Mono.Cecil {
 			return version.Major == 0 && version.Minor == 0 && version.Build == 0 && version.Revision == 0;
 		}
 
-#if !NET_CORE
 		AssemblyDefinition GetCorlib (AssemblyNameReference reference, ReaderParameters parameters)
 		{
 			var version = reference.Version;
@@ -380,7 +377,7 @@ namespace Mono.Cecil {
 
 			return null;
 		}
-#endif
+
 		static string GetAssemblyFile (AssemblyNameReference reference, string prefix, string gac)
 		{
 			var gac_folder = new StringBuilder ()

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -211,9 +211,7 @@ namespace Mono.Cecil {
 		Stream symbol_stream;
 		ISymbolWriterProvider symbol_writer_provider;
 		bool write_symbols;
-#if !NET_CORE
 		SR.StrongNameKeyPair key_pair;
-#endif
 
 		public uint? Timestamp {
 			get { return timestamp; }
@@ -235,12 +233,10 @@ namespace Mono.Cecil {
 			set { write_symbols = value; }
 		}
 
-#if !NET_CORE
 		public SR.StrongNameKeyPair StrongNameKeyPair {
 			get { return key_pair; }
 			set { key_pair = value; }
 		}
-#endif
 	}
 
 #endif

--- a/Mono.Security.Cryptography/CryptoConvert.cs
+++ b/Mono.Security.Cryptography/CryptoConvert.cs
@@ -29,8 +29,6 @@
 
 #if !READ_ONLY
 
-#if !NET_CORE
-
 using System;
 using System.Security.Cryptography;
 
@@ -248,6 +246,3 @@ namespace Mono.Security.Cryptography {
 }
 
 #endif
-
-#endif
-

--- a/Mono.Security.Cryptography/CryptoService.cs
+++ b/Mono.Security.Cryptography/CryptoService.cs
@@ -10,8 +10,6 @@
 
 #if !READ_ONLY
 
-#if !NET_CORE
-
 using System;
 using System.IO;
 using System.Reflection;
@@ -152,7 +150,5 @@ namespace Mono.Cecil {
 		}
 	}
 }
-
-#endif
 
 #endif


### PR DESCRIPTION
### Changed the target runtime to .NET Standard 2.0.

Removed some conditional compilation ifs that were
removing the ability to strong name code.
Bring back code in BaseAssemblyResolver that builds on
.NET Standard 2.0, enabling the search of assemblies in the
GAC, allowing the code to find assemblies in the GAC, even when
referenced from a net461 DLL in .NET Framework full.

I am not sure if the .NET Standard 2.0 DLL assemblies referenced in the nuspec file needs to be updated or not.

I ran the tests in .NET Standard 2.0 and all worked.

This PR is motivated by https://github.com/dsplaisted/strongnamer/pull/31, in an effort to make it available on Linux. Sadly, this is not fully possible as of https://github.com/dotnet/corefx/issues/11225.
