### PR TITLE
Fix #550: Fix flag test to correctly skip parameters

### DIFF
--- a/symbols/pdb/Mono.Cecil.Pdb/NativePdbReader.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/NativePdbReader.cs
@@ -183,12 +183,12 @@ namespace Mono.Cecil.Pdb {
 				parent.variables = new Collection<VariableDebugInformation> (scope.slots.Length);
 
 				foreach (PdbSlot slot in scope.slots) {
-					if (slot.flags == 1) // parameter names
+					if ((slot.flags & 1) != 0) // parameter names
 						continue;
 
 					var index = (int) slot.slot;
 					var variable = new VariableDebugInformation (index, slot.name);
-					if (slot.flags == 4)
+					if ((slot.flags & 4) != 0)
 						variable.IsDebuggerHidden = true;
 					parent.variables.Add (variable);
 				}


### PR DESCRIPTION
Some parameters (for example in C++ CLI code) where mistakenly counted as
local variables. The flags are a bit-mask and should be tested with a mask.

Official MS documentation of the flags: https://goo.gl/RF9dXy