### PR TITLE
Restored full path in filename property

### DIFF
--- a/Mono.Cecil.Cil/PortablePdb.cs
+++ b/Mono.Cecil.Cil/PortablePdb.cs
@@ -318,9 +318,7 @@ namespace Mono.Cecil.Cil {
 			// PDB Age
 			buffer.WriteUInt32 (1);
 			// PDB Path
-			var filename = writer.BaseStream.GetFileName ();
-			if (!string.IsNullOrEmpty (filename))
-				filename = Path.GetFileName (filename);
+			var filename = ImageDebugHeader.ReadFilePath (module.GetDebugHeader ());
 
 			buffer.WriteBytes (System.Text.Encoding.UTF8.GetBytes (filename));
 			buffer.WriteByte (0);

--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -66,6 +66,19 @@ namespace Mono.Cecil.Cil {
 			: this (new [] { entry })
 		{
 		}
+
+		public static string ReadFilePath (ImageDebugHeader header)
+		{
+			var bytesToSkip = 4 + 16 + 4; //id + guid + postfix
+
+			var data = header.Entries [0].Data;
+			var length = data.Length - bytesToSkip;
+			var filePath = new byte[length];
+
+			Array.Copy(data, bytesToSkip, filePath, 0, length - 1);
+
+			return System.Text.Encoding.UTF8.GetString(filePath).TrimEnd ('\0');
+		}
 	}
 
 	public sealed class ImageDebugHeaderEntry {


### PR DESCRIPTION
UWP uses the filename property to find the pdb file when debugging. Changing the value that's already in the dll to just the filename renders the debugger unable to find the pdb file, and UWP debugging then works with no symbols (meaning, no breakpoints and not pausing and stepping). The lines I removed seem intentional, though, so I'm opening this for discussion. This is at the moment affecting the XamlG task in Xamarin Forms, but it also probably affects other clients of Cecil like Fody. Android and iOS are not affected by this because the logic for finding the pdb in the mono debugger is slightly different than what it is in the .Net debugger.