### PR TITLE
Fix the read only build

### DIFF
--- a/Test/Mono.Cecil.Tests/TypeTests.cs
+++ b/Test/Mono.Cecil.Tests/TypeTests.cs
@@ -30,6 +30,8 @@ namespace Mono.Cecil.Tests {
 			});
 		}
 
+#if !READ_ONLY
+
 		[Test]
 		public void EmptyStructLayout ()
 		{
@@ -42,6 +44,8 @@ namespace Mono.Cecil.Tests {
 				module.Types.Add (foo) ;
 			}) ;
 		}
+
+#endif
 
 		[Test]
 		public void SimpleInterfaces ()


### PR DESCRIPTION
Building of the project with `READ_ONLY` defined failed with this error
```
"C:\Dev\cecil\Mono.Cecil.sln" (default target) (1) ->
"C:\Dev\cecil\Test\Mono.Cecil.Tests.csproj" (default target) (3) ->
(CoreCompile target) ->
  Mono.Cecil.Tests\TypeTests.cs(40,13): error CS1061: 'ModuleDefinition' does not contain a definition for 'ImportReference' and no accessible extension method 'ImportReference' accepting a first argument of type 'ModuleDefinition' could be found (are you missing a using directive or an assembly reference?) [C:\Dev\cecil\Test\Mono.Cecil.Tests.csproj]
```
Apparently, the method is not available with READ_ONLY defined, as we can see the method is defined on [line 765](https://github.com/jbevain/cecil/blob/232772d59e03c3f32cce5418b5ddc392fab7d994/Mono.Cecil/ModuleDefinition.cs#L765) but is excluded from the build on [line 748](https://github.com/jbevain/cecil/blob/232772d59e03c3f32cce5418b5ddc392fab7d994/Mono.Cecil/ModuleDefinition.cs#L748)

Therefore the clear fix is to exclude the unit test when `READ_ONLY` is defined. That is the only build error I found, with this fixed, the build passes.