### PR TITLE
Fix the netstandard build

### DIFF
--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -943,7 +943,11 @@ namespace Mono.Cecil.Cil {
 			var name = new SR.AssemblyName {
 				Name = cecil_name.Name + "." + suffix,
 				Version = cecil_name.Version,
+#if NET_CORE
+				CultureName = cecil_name.CultureName,
+#else
 				CultureInfo = cecil_name.CultureInfo,
+#endif
 			};
 
 			name.SetPublicKeyToken (cecil_name.GetPublicKeyToken ());


### PR DESCRIPTION
The property `System.Reflection.AssemblyName.CultureInfo` is not available for netstandard1.3, the right property  is `System.Reflection.AssemblyName.CultureName`.

[Here](https://github.com/dotnet/standard/blob/master/docs/versions/netstandard1.3_ref.md) are the API references, you can search `class AssemblyName` in that document to confirm it.