### PR TITLE
Remove internal IMetadataSymbolWriter that prevents external composition of symbol writers

### DIFF
--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -287,6 +287,10 @@ namespace Mono.Cecil {
 
 		internal Collection<CustomDebugInformation> custom_infos;
 
+#if !READ_ONLY
+		internal MetadataBuilder metadata_builder;
+#endif
+
 		public bool IsMain {
 			get { return kind != ModuleKind.NetModule; }
 		}

--- a/symbols/pdb/Mono.Cecil.Pdb/NativePdbWriter.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/NativePdbWriter.cs
@@ -22,18 +22,18 @@ using Mono.Collections.Generic;
 
 namespace Mono.Cecil.Pdb {
 
-	public class NativePdbWriter : ISymbolWriter, IMetadataSymbolWriter {
+	public class NativePdbWriter : ISymbolWriter {
 
 		readonly ModuleDefinition module;
+		readonly MetadataBuilder metadata;
 		readonly SymWriter writer;
 		readonly Dictionary<string, SymDocumentWriter> documents;
 		readonly Dictionary<ImportDebugInformation, MetadataToken> import_info_to_parent;
 
-		MetadataBuilder metadata;
-
 		internal NativePdbWriter (ModuleDefinition module, SymWriter writer)
 		{
 			this.module = module;
+			this.metadata = module.metadata_builder;
 			this.writer = writer;
 			this.documents = new Dictionary<string, SymDocumentWriter> ();
 			this.import_info_to_parent = new Dictionary<ImportDebugInformation, MetadataToken> ();
@@ -73,15 +73,6 @@ namespace Mono.Cecil.Pdb {
 			DefineCustomMetadata (info, import_parent);
 
 			writer.CloseMethod ();
-		}
-
-		void IMetadataSymbolWriter.SetMetadata (MetadataBuilder metadata)
-		{
-			this.metadata = metadata;
-		}
-
-		void IMetadataSymbolWriter.WriteModule ()
-		{
 		}
 
 		void DefineCustomMetadata (MethodDebugInformation info, MetadataToken import_parent)


### PR DESCRIPTION
This fixes scenarios where we the user wants to provide its own ` ISymbolWriterProvider` and own `ISymbolWriter` that wraps Cecil's `ISymbolWriter` implementation, as in:

https://github.com/jbevain/cecil/pull/554#issuecomment-457880112