### PR TITLE
Fix off-by-one error in SignatureReader.ReadUTF8String()

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -3769,7 +3769,7 @@ namespace Mono.Cecil {
 			if (length == 0)
 				return string.Empty;
 
-			if (position + length >= buffer.Length)
+			if (position + length > buffer.Length)
 				return string.Empty;
 
 			var @string = Encoding.UTF8.GetString (buffer, position, length);


### PR DESCRIPTION
If `position + length` was exactly `buffer.Length` we'd return an empty string instead of the correct value.

Unfortunately it seems to be hard to recreate this as a testcase that works on Windows.