### PR TITLE
Add I8 and UI8 fields to the VariantType enum

### DIFF
--- a/Mono.Cecil/VariantType.cs
+++ b/Mono.Cecil/VariantType.cs
@@ -29,6 +29,8 @@ namespace Mono.Cecil {
 		UI1 = 17,
 		UI2 = 18,
 		UI4 = 19,
+		I8 = 20,
+		UI8 = 21,
 		Int = 22,
 		UInt = 23
 	}


### PR DESCRIPTION
These fields are useful for dealing with `SAFEARRAY` marshaling. They
match the definition in the `VARENUM` in the Win32 C API.