### PR TITLE
Changing PdbReaderProvider to accept create EmbeddedPDB from stream.

### DIFF
--- a/Test/Mono.Cecil.Tests/BaseTestFixture.cs
+++ b/Test/Mono.Cecil.Tests/BaseTestFixture.cs
@@ -137,11 +137,6 @@ namespace Mono.Cecil.Tests {
 			Run (new ILTestCase (file, test, verify, readOnly, symbolReaderProvider, symbolWriterProvider, assemblyResolver, applyWindowsRuntimeProjections, sourceFilePath));
 		}
 
-		public static void TestBinary (string file, Action<ModuleDefinition> test, bool verify = true, bool readOnly = true, Type symbolReaderProvider = null, Type symbolWriterProvider = null, IAssemblyResolver assemblyResolver = null, bool applyWindowsRuntimeProjections = false, [CallerFilePath] string sourceFilePath = "")
-		{
-			Run (new BinaryTestCase (file, test, verify, readOnly, symbolReaderProvider, symbolWriterProvider, assemblyResolver, applyWindowsRuntimeProjections, sourceFilePath));
-		}
-
 		static void Run (TestCase testCase)
 		{
 			using (var runner = new TestRunner (testCase, TestCaseType.ReadDeferred))
@@ -240,22 +235,7 @@ namespace Mono.Cecil.Tests {
 			}
 		}
 	}
-	class BinaryTestCase : ModuleTestCase {
 
-		public BinaryTestCase (string file, Action<ModuleDefinition> test, bool verify, bool readOnly, Type symbolReaderProvider, Type symbolWriterProvider, IAssemblyResolver assemblyResolver, bool applyWindowsRuntimeProjections, string sourceFilePath = "")
-			: base (file, test, verify, readOnly, symbolReaderProvider, symbolWriterProvider, assemblyResolver, applyWindowsRuntimeProjections, sourceFilePath)
-		{
-		}
-
-		public byte[] BinaryStream
-		{
-			get
-			{
-				byte[] bytes = System.IO.File.ReadAllBytes(ModuleLocation);
-				return bytes;
-			}
-		}
-	}
 	class TestRunner : IDisposable {
 
 		readonly TestCase test_case;
@@ -293,28 +273,6 @@ namespace Mono.Cecil.Tests {
 			case TestCaseType.WriteFromDeferred:
 				parameters.ReadingMode = ReadingMode.Deferred;
 				return RoundTrip (location, parameters, "cecil-drt");
-			default:
-				return null;
-			}
-		}
-
-		ModuleDefinition GetModuleFromBinary ()
-		{
-			var test_case_binary = test_case as BinaryTestCase;
-			var stream = test_case_binary.BinaryStream;
-
-			var parameters = new ReaderParameters {
-				SymbolReaderProvider = GetSymbolReaderProvider (),
-				AssemblyResolver = GetAssemblyResolver ()
-			};
-
-			switch (type) {
-			case TestCaseType.ReadImmediate:
-				parameters.ReadingMode = ReadingMode.Immediate;
-				return ModuleDefinition.ReadModule (new MemoryStream(stream), parameters);
-			case TestCaseType.ReadDeferred:
-				parameters.ReadingMode = ReadingMode.Deferred;
-				return ModuleDefinition.ReadModule (new MemoryStream (stream), parameters);
 			default:
 				return null;
 			}
@@ -372,11 +330,7 @@ namespace Mono.Cecil.Tests {
 
 		public void RunTest ()
 		{
-			ModuleDefinition module;
-			if (test_case is BinaryTestCase)
-				module = GetModuleFromBinary();
-			else
-				module = GetModule ();
+			var module = GetModule ();
 			if (module == null)
 				return;
 

--- a/Test/Mono.Cecil.Tests/PortablePdbTests.cs
+++ b/Test/Mono.Cecil.Tests/PortablePdbTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using NUnit.Framework;
 
 using Mono.Cecil.Cil;
+using Mono.Cecil.Pdb;
 using Mono.Cecil.PE;
 
 namespace Mono.Cecil.Tests {
@@ -367,6 +368,28 @@ namespace Mono.Cecil.Tests {
 				Assert.AreEqual (0x0100, eppdb.Directory.MinorVersion);
 			}, symbolReaderProvider: typeof (EmbeddedPortablePdbReaderProvider), symbolWriterProvider: typeof (EmbeddedPortablePdbWriterProvider));
 		}
+
+		[Test]
+		public void EmbeddedCompressedPortablePdbFromStream ()
+		{
+			TestBinary("EmbeddedCompressedPdbTarget.exe", module => {
+				Assert.IsTrue (module.HasDebugHeader);
+
+				var header = module.GetDebugHeader ();
+
+				Assert.IsNotNull (header);
+				Assert.AreEqual (2, header.Entries.Length);
+
+				var cv = header.Entries [0];
+				Assert.AreEqual (ImageDebugType.CodeView, cv.Directory.Type);
+
+				var eppdb = header.Entries [1];
+				Assert.AreEqual (ImageDebugType.EmbeddedPortablePdb, eppdb.Directory.Type);
+				Assert.AreEqual (0x0100, eppdb.Directory.MajorVersion);
+				Assert.AreEqual (0x0100, eppdb.Directory.MinorVersion);
+			}, symbolReaderProvider: typeof (PdbReaderProvider), symbolWriterProvider: null);
+		}
+
 
 		void TestPortablePdbModule (Action<ModuleDefinition> test)
 		{

--- a/Test/Mono.Cecil.Tests/PortablePdbTests.cs
+++ b/Test/Mono.Cecil.Tests/PortablePdbTests.cs
@@ -372,22 +372,27 @@ namespace Mono.Cecil.Tests {
 		[Test]
 		public void EmbeddedCompressedPortablePdbFromStream ()
 		{
-			TestBinary("EmbeddedCompressedPdbTarget.exe", module => {
-				Assert.IsTrue (module.HasDebugHeader);
+			var bytes = File.ReadAllBytes (GetAssemblyResourcePath ("EmbeddedCompressedPdbTarget.exe"));
+			var parameters = new ReaderParameters {
+				ReadSymbols = true,
+				SymbolReaderProvider = new PdbReaderProvider ()
+			};
 
-				var header = module.GetDebugHeader ();
+			var module = ModuleDefinition.ReadModule (new MemoryStream(bytes), parameters);
+			Assert.IsTrue (module.HasDebugHeader);
 
-				Assert.IsNotNull (header);
-				Assert.AreEqual (2, header.Entries.Length);
+			var header = module.GetDebugHeader ();
 
-				var cv = header.Entries [0];
-				Assert.AreEqual (ImageDebugType.CodeView, cv.Directory.Type);
+			Assert.IsNotNull (header);
+			Assert.AreEqual (2, header.Entries.Length);
 
-				var eppdb = header.Entries [1];
-				Assert.AreEqual (ImageDebugType.EmbeddedPortablePdb, eppdb.Directory.Type);
-				Assert.AreEqual (0x0100, eppdb.Directory.MajorVersion);
-				Assert.AreEqual (0x0100, eppdb.Directory.MinorVersion);
-			}, symbolReaderProvider: typeof (PdbReaderProvider), symbolWriterProvider: null);
+			var cv = header.Entries [0];
+			Assert.AreEqual (ImageDebugType.CodeView, cv.Directory.Type);
+
+			var eppdb = header.Entries [1];
+			Assert.AreEqual (ImageDebugType.EmbeddedPortablePdb, eppdb.Directory.Type);
+			Assert.AreEqual (0x0100, eppdb.Directory.MajorVersion);
+			Assert.AreEqual (0x0100, eppdb.Directory.MinorVersion);
 		}
 
 

--- a/symbols/pdb/Mono.Cecil.Pdb/PdbHelper.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/PdbHelper.cs
@@ -39,7 +39,6 @@ namespace Mono.Cecil.Pdb {
 		public ISymbolReader GetSymbolReader (ModuleDefinition module, string fileName)
 		{
 			Mixin.CheckModule (module);
-			Mixin.CheckFileName (fileName);
 
 			if (module.HasDebugHeader) {
 				var header = module.GetDebugHeader ();
@@ -47,6 +46,8 @@ namespace Mono.Cecil.Pdb {
 				if (entry != null)
 					return new EmbeddedPortablePdbReaderProvider ().GetSymbolReader (module, fileName);
 			}
+			
+			Mixin.CheckFileName (fileName);
 
 			return Mixin.IsPortablePdb (Mixin.GetPdbFileName (fileName))
 				? new PortablePdbReaderProvider ().GetSymbolReader (module, fileName)


### PR DESCRIPTION
Changing GetSymbolReader from PdbReaderProvider, when we create a Module from stream  we don't have the filename, and it's not necessary to create an EmbeddedPortablePdbReaderProvider, so I've moved the check to after the creation of EmbeddedPortablePdbReaderProvider.