### PR TITLE
add strong key pair for NET Standard

### DIFF
--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -13,6 +13,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using SR = System.Reflection;
+#if (NETSTANDARD)
+using StrongNameKeyPair=Mono.Cecil.StrongNameKeyPair;
+#else
+using StrongNameKeyPair=System.Reflection.StrongNameKeyPair;
+#endif
 
 using Mono.Cecil.Cil;
 using Mono.Cecil.Metadata;
@@ -185,7 +190,7 @@ namespace Mono.Cecil {
 		bool write_symbols;
 		byte [] key_blob;
 		string key_container;
-		SR.StrongNameKeyPair key_pair;
+		StrongNameKeyPair key_pair;
 
 		public uint? Timestamp {
 			get { return timestamp; }
@@ -221,7 +226,7 @@ namespace Mono.Cecil {
 			set { key_container = value; }
 		}
 
-		public SR.StrongNameKeyPair StrongNameKeyPair {
+		public StrongNameKeyPair StrongNameKeyPair {
 			get { return key_pair; }
 			set { key_pair = value; }
 		}

--- a/Mono.Cecil/StrongNameKeyPair.cs
+++ b/Mono.Cecil/StrongNameKeyPair.cs
@@ -1,0 +1,132 @@
+﻿#if (NETSTANDARD)
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Security;
+using System.Security.Cryptography;
+
+namespace Mono.Cecil {
+	[Serializable]
+	public class StrongNameKeyPair : ISerializable {
+		bool _keyPairExported;
+		byte [] _keyPairArray;
+		string _keyPairContainer;
+		byte [] _publicKey;
+
+		public byte [] PublicKey {
+			[SecuritySafeCritical]
+			get {
+				if (_publicKey == null) {
+					_publicKey = ComputePublicKey ();
+				}
+
+				byte [] array = new byte[_publicKey.Length];
+				Array.Copy (_publicKey, array, _publicKey.Length);
+				return array;
+			}
+		}
+
+		public StrongNameKeyPair (FileStream keyPairFile)
+		{
+			if (keyPairFile == null) {
+				throw new ArgumentNullException ("keyPairFile");
+			}
+
+			var num = (int) keyPairFile.Length;
+			_keyPairArray = new byte[num];
+			keyPairFile.Read (_keyPairArray, 0, num);
+			_keyPairExported = true;
+		}
+
+		public StrongNameKeyPair (byte [] keyPairArray)
+		{
+			if (keyPairArray == null) {
+				throw new ArgumentNullException ("keyPairArray");
+			}
+
+			_keyPairArray = new byte[keyPairArray.Length];
+			Array.Copy (keyPairArray, _keyPairArray, keyPairArray.Length);
+			_keyPairExported = true;
+		}
+
+		public StrongNameKeyPair (string keyPairContainer)
+		{
+			if (keyPairContainer == null) {
+				throw new ArgumentNullException ("keyPairContainer");
+			}
+
+			_keyPairContainer = keyPairContainer;
+			_keyPairExported = false;
+		}
+
+		protected StrongNameKeyPair (SerializationInfo info, StreamingContext context)
+		{
+			_keyPairExported = (bool) info.GetValue ("_keyPairExported", typeof(bool));
+			_keyPairArray = (byte []) info.GetValue ("_keyPairArray", typeof(byte []));
+			_keyPairContainer = (string) info.GetValue ("_keyPairContainer", typeof(string));
+			_publicKey = (byte []) info.GetValue ("_publicKey", typeof(byte []));
+		}
+
+		byte [] ComputePublicKey ()
+		{
+			using (var rsa = Mixin.CreateRSA (this)) {
+				var cspBlob = ToCapiPublicKeyBlob (rsa);
+				var publicKey = new byte[12 + cspBlob.Length];
+				Buffer.BlockCopy (cspBlob, 0, publicKey, 12, cspBlob.Length);
+				// The first 12 bytes are documented at:
+				// http://msdn.microsoft.com/library/en-us/cprefadd/html/grfungethashfromfile.asp
+				// ALG_ID - Signature
+				publicKey [1] = 36;
+				// ALG_ID - Hash
+				publicKey [4] = 4;
+				publicKey [5] = 128;
+				// Length of Public Key (in bytes)
+				publicKey [8] = (byte) (cspBlob.Length >> 0);
+				publicKey [9] = (byte) (cspBlob.Length >> 8);
+				publicKey [10] = (byte) (cspBlob.Length >> 16);
+				publicKey [11] = (byte) (cspBlob.Length >> 24);
+				return publicKey;
+			}
+		}
+
+		void ISerializable.GetObjectData (SerializationInfo info, StreamingContext context)
+		{
+			info.AddValue ("_keyPairExported", _keyPairExported);
+			info.AddValue ("_keyPairArray", _keyPairArray);
+			info.AddValue ("_keyPairContainer", _keyPairContainer);
+			info.AddValue ("_publicKey", _publicKey);
+		}
+
+		static byte [] ToCapiPublicKeyBlob (RSA rsa)
+		{
+			var rsap = rsa.ExportParameters (false);
+			var blob = new byte[rsap.Modulus.Length + 20];
+			blob [0] = 0x06; // PUBLICKEYBLOB (0x06)
+			blob [1] = 0x02; // Version (0x02)
+			blob [2] = 0x00; // Reserved (word)
+			blob [3] = 0x00;
+			blob [5] = 0x24; // ALGID
+			WriteUInt32LE (blob, 8, 0x31415352); // DWORD magic = RSA1
+			WriteUInt32LE (blob, 12, (uint) rsap.Modulus.Length << 3); // DWORD bitlen
+
+			// DWORD public exponent
+			blob [18] = rsap.Exponent [0];
+			blob [17] = rsap.Exponent [1];
+			blob [16] = rsap.Exponent [2];
+
+			// BYTE modulus[rsapubkey.bitlen/8];
+			Array.Reverse (rsap.Modulus);
+			Buffer.BlockCopy (rsap.Modulus, 0, blob, 20, rsap.Modulus.Length);
+			return blob;
+		}
+
+		static void WriteUInt32LE (byte [] bytes, int offset, uint value)
+		{
+			bytes [offset + 3] = (byte) (value >> 24);
+			bytes [offset + 2] = (byte) (value >> 16);
+			bytes [offset + 1] = (byte) (value >> 8);
+			bytes [offset] = (byte) value;
+		}
+	}
+}
+#endif

--- a/Mono.Cecil/StrongNameKeyPair.cs
+++ b/Mono.Cecil/StrongNameKeyPair.cs
@@ -1,4 +1,4 @@
-﻿#if (NETSTANDARD)
+#if (NETSTANDARD)
 using System;
 using System.IO;
 using System.Runtime.Serialization;

--- a/Mono.Cecil/StrongNameKeyPair.cs
+++ b/Mono.Cecil/StrongNameKeyPair.cs
@@ -129,4 +129,27 @@ namespace Mono.Cecil {
 		}
 	}
 }
+#else
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Mono.Cecil {
+	public class StrongNameKeyPair : System.Reflection.StrongNameKeyPair {
+		public StrongNameKeyPair(FileStream keyPairFile) : base(keyPairFile)
+		{
+		}
+
+		public StrongNameKeyPair(byte[] keyPairArray) : base(keyPairArray)
+		{
+		}
+
+		public StrongNameKeyPair(string keyPairContainer) : base(keyPairContainer)
+		{
+		}
+
+		protected StrongNameKeyPair(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
+	}
+}
 #endif


### PR DESCRIPTION
Hi @SimonCropp and @jbevain I followed up on the suggestion in #548

Not sure if my 54a8987 is helpful, I can easily remove it if you feel like it's a bad addition.

For our use case it meant we could remove `using System.Reflection` and avoid the same 
```
#if (NETSTANDARD)
using StrongNameKeyPair=Mono.Cecil.StrongNameKeyPair;
#else
using StrongNameKeyPair=System.Reflection.StrongNameKeyPair;
#endif
```

In all our files that used StrongNameKeyPair.