### PR TITLE
Add a way to read PE images loaded in memory.

### DIFF
--- a/Mono.Cecil.PE/Image.cs
+++ b/Mono.Cecil.PE/Image.cs
@@ -23,6 +23,7 @@ namespace Mono.Cecil.PE {
 
 		public Disposable<Stream> Stream;
 		public string FileName;
+		public bool ImageLayoutInMemory;
 
 		public ModuleKind Kind;
 		public string RuntimeVersion;
@@ -90,6 +91,9 @@ namespace Mono.Cecil.PE {
 
 		public uint ResolveVirtualAddress (RVA rva)
 		{
+			if (ImageLayoutInMemory)
+				return rva;
+
 			var section = GetSectionAtVirtualAddress (rva);
 			if (section == null)
 				throw new ArgumentOutOfRangeException ();
@@ -99,6 +103,9 @@ namespace Mono.Cecil.PE {
 
 		public uint ResolveVirtualAddressInSection (RVA rva, Section section)
 		{
+			if (ImageLayoutInMemory)
+				return rva;
+
 			return rva + section.PointerToRawData - section.VirtualAddress;
 		}
 

--- a/Mono.Cecil.PE/ImageReader.cs
+++ b/Mono.Cecil.PE/ImageReader.cs
@@ -382,7 +382,7 @@ namespace Mono.Cecil.PE {
 			var relativeOffset = ReadUInt32 ();
 			uint offset = image.ImageLayoutInMemory
 				? metadata.VirtualAddress + relativeOffset // relative to the metadata start
-                : metadata.VirtualAddress - section.VirtualAddress + relativeOffset; // relative to the section start
+				: metadata.VirtualAddress - section.VirtualAddress + relativeOffset; // relative to the section start
 
 			// Size			4
 			uint size = ReadUInt32 ();

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -40,6 +40,7 @@ namespace Mono.Cecil {
 		bool projections;
 		bool in_memory;
 		bool read_write;
+		bool image_layout_in_memory;
 
 		public ReadingMode ReadingMode {
 			get { return reading_mode; }
@@ -99,6 +100,11 @@ namespace Mono.Cecil {
 		public bool ApplyWindowsRuntimeProjections {
 			get { return projections; }
 			set { projections = value; }
+		}
+
+		public bool ImageLayoutInMemory {
+			get { return image_layout_in_memory; }
+			set { image_layout_in_memory = value; }
 		}
 
 		public ReaderParameters ()
@@ -1123,7 +1129,7 @@ namespace Mono.Cecil {
 			Mixin.CheckParameters (parameters);
 
 			return ModuleReader.CreateModule (
-				ImageReader.ReadImage (stream, fileName),
+				ImageReader.ReadImage (stream, fileName, parameters.ImageLayoutInMemory),
 				parameters);
 		}
 


### PR DESCRIPTION
It is useful when inspecting modules loaded into a live process or reading process dump files.

On disk RVAs must be mapped to stream contents using section header mapping information. In memory RVAs can be used as direct offsets into the stream.