### PR TITLE
Automatically update local variable debug info

### DIFF
--- a/Mono.Cecil.Cil/CodeReader.cs
+++ b/Mono.Cecil.Cil/CodeReader.cs
@@ -132,7 +132,7 @@ namespace Mono.Cecil.Cil {
 		public VariableDefinitionCollection ReadVariables (MetadataToken local_var_token)
 		{
 			var position = reader.position;
-			var variables = reader.ReadVariables (local_var_token);
+			var variables = reader.ReadVariables (local_var_token, method);
 			reader.position = position;
 
 			return variables;

--- a/Mono.Cecil.Cil/MethodBody.cs
+++ b/Mono.Cecil.Cil/MethodBody.cs
@@ -165,11 +165,11 @@ namespace Mono.Cecil.Cil {
 
 		protected override void OnRemove (VariableDefinition item, int index)
 		{
-			UpdateVariableIndices (index + 1, -1, index, item);
+			UpdateVariableIndices (index + 1, -1, item);
 			item.index = -1;
 		}
 
-		void UpdateVariableIndices (int startIndex, int offset, int indexToRemove = -1, VariableDefinition variableToRemove = null)
+		void UpdateVariableIndices (int startIndex, int offset, VariableDefinition variableToRemove = null)
 		{
 			for (int i = startIndex; i < size; i++)
 				items [i].index = i + offset;
@@ -184,12 +184,18 @@ namespace Mono.Cecil.Cil {
 					int variableDebugInfoIndexToRemove = -1;
 					for (int i = 0; i < variables.Count; i++) {
 						var variable = variables [i];
-						if ((variableToRemove != null && variable.index.IsResolved && variable.index.ResolvedVariable == variableToRemove) ||
-							(indexToRemove != -1 && variable.Index == indexToRemove)) {
+
+						// If a variable is being removed detect if it has debug info counterpart, if so remove that as well.
+						// Note that the debug info can be either resolved (has direct reference to the VariableDefinition)
+						// or unresolved (has only the number index of the variable) - this needs to handle both cases.
+						if (variableToRemove != null &&
+							((variable.index.IsResolved && variable.index.ResolvedVariable == variableToRemove) ||
+							 (!variable.index.IsResolved && variable.Index == variableToRemove.Index))) {
 							variableDebugInfoIndexToRemove = i;
 							continue;
 						}
 
+						// For unresolved debug info updates indeces to keep them pointing to the same variable.
 						if (!variable.index.IsResolved && variable.Index >= startIndex) {
 							variable.index = new VariableIndex (variable.Index + offset);
 						}

--- a/Mono.Cecil.Cil/MethodBody.cs
+++ b/Mono.Cecil.Cil/MethodBody.cs
@@ -179,31 +179,32 @@ namespace Mono.Cecil.Cil {
 				return;
 
 			foreach (var scope in debug_info.GetScopes ()) {
-				if (scope.HasVariables) {
-					var variables = scope.Variables;
-					int variableDebugInfoIndexToRemove = -1;
-					for (int i = 0; i < variables.Count; i++) {
-						var variable = variables [i];
+				if (!scope.HasVariables)
+					continue;
 
-						// If a variable is being removed detect if it has debug info counterpart, if so remove that as well.
-						// Note that the debug info can be either resolved (has direct reference to the VariableDefinition)
-						// or unresolved (has only the number index of the variable) - this needs to handle both cases.
-						if (variableToRemove != null &&
-							((variable.index.IsResolved && variable.index.ResolvedVariable == variableToRemove) ||
-							 (!variable.index.IsResolved && variable.Index == variableToRemove.Index))) {
-							variableDebugInfoIndexToRemove = i;
-							continue;
-						}
+				var variables = scope.Variables;
+				int variableDebugInfoIndexToRemove = -1;
+				for (int i = 0; i < variables.Count; i++) {
+					var variable = variables [i];
 
-						// For unresolved debug info updates indeces to keep them pointing to the same variable.
-						if (!variable.index.IsResolved && variable.Index >= startIndex) {
-							variable.index = new VariableIndex (variable.Index + offset);
-						}
+					// If a variable is being removed detect if it has debug info counterpart, if so remove that as well.
+					// Note that the debug info can be either resolved (has direct reference to the VariableDefinition)
+					// or unresolved (has only the number index of the variable) - this needs to handle both cases.
+					if (variableToRemove != null &&
+						((variable.index.IsResolved && variable.index.ResolvedVariable == variableToRemove) ||
+							(!variable.index.IsResolved && variable.Index == variableToRemove.Index))) {
+						variableDebugInfoIndexToRemove = i;
+						continue;
 					}
 
-					if (variableDebugInfoIndexToRemove >= 0)
-						variables.RemoveAt (variableDebugInfoIndexToRemove);
+					// For unresolved debug info updates indeces to keep them pointing to the same variable.
+					if (!variable.index.IsResolved && variable.Index >= startIndex) {
+						variable.index = new VariableIndex (variable.Index + offset);
+					}
 				}
+
+				if (variableDebugInfoIndexToRemove >= 0)
+					variables.RemoveAt (variableDebugInfoIndexToRemove);
 			}
 		}
 	}

--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -231,7 +231,7 @@ namespace Mono.Cecil.Cil {
 
 	public struct VariableIndex {
 		readonly VariableDefinition variable;
-		internal int? index;
+		readonly int? index;
 
 		public int Index {
 			get {
@@ -243,6 +243,10 @@ namespace Mono.Cecil.Cil {
 				throw new NotSupportedException ();
 			}
 		}
+
+		internal bool IsResolved => variable != null;
+
+		internal VariableDefinition ResolvedVariable => variable;
 
 		public VariableIndex (VariableDefinition variable)
 		{

--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -231,7 +231,7 @@ namespace Mono.Cecil.Cil {
 
 	public struct VariableIndex {
 		readonly VariableDefinition variable;
-		readonly int? index;
+		internal int? index;
 
 		public int Index {
 			get {

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -2141,7 +2141,7 @@ namespace Mono.Cecil {
 			return call_site;
 		}
 
-		public VariableDefinitionCollection ReadVariables (MetadataToken local_var_token)
+		public VariableDefinitionCollection ReadVariables (MetadataToken local_var_token, MethodDefinition method = null)
 		{
 			if (!MoveTo (Table.StandAloneSig, local_var_token.RID))
 				return null;
@@ -2156,7 +2156,7 @@ namespace Mono.Cecil {
 			if (count == 0)
 				return null;
 
-			var variables = new VariableDefinitionCollection ((int) count);
+			var variables = new VariableDefinitionCollection (method, (int) count);
 
 			for (int i = 0; i < count; i++)
 				variables.Add (new VariableDefinition (reader.ReadTypeSignature ()));

--- a/Test/Mono.Cecil.Tests/VariableTests.cs
+++ b/Test/Mono.Cecil.Tests/VariableTests.cs
@@ -81,6 +81,45 @@ namespace Mono.Cecil.Tests {
 		}
 
 		[Test]
+		public void RemoveVariableWithDebugInfo ()
+		{
+			var object_ref = new TypeReference ("System", "Object", null, null, false);
+			var method = new MethodDefinition ("foo", MethodAttributes.Static, object_ref);
+			var body = new MethodBody (method);
+			var il = body.GetILProcessor ();
+			il.Emit (OpCodes.Ret);
+
+			var x = new VariableDefinition (object_ref);
+			var y = new VariableDefinition (object_ref);
+			var z = new VariableDefinition (object_ref);
+			var z2 = new VariableDefinition (object_ref);
+
+			body.Variables.Add (x);
+			body.Variables.Add (y);
+			body.Variables.Add (z);
+			body.Variables.Add (z2);
+
+			var scope = new ScopeDebugInformation (body.Instructions [0], body.Instructions [0]);
+			method.DebugInformation = new MethodDebugInformation (method) {
+				Scope = scope
+			};
+			scope.Variables.Add (new VariableDebugInformation (x.index, nameof (x)));
+			scope.Variables.Add (new VariableDebugInformation (y.index, nameof (y)));
+			scope.Variables.Add (new VariableDebugInformation (z.index, nameof (z)));
+			scope.Variables.Add (new VariableDebugInformation (z2, nameof (z2)));
+
+			body.Variables.Remove (y);
+
+			Assert.AreEqual (3, scope.Variables.Count);
+			Assert.AreEqual (x.Index, scope.Variables [0].Index);
+			Assert.AreEqual (nameof (x), scope.Variables [0].Name);
+			Assert.AreEqual (z.Index, scope.Variables [1].Index);
+			Assert.AreEqual (nameof (z), scope.Variables [1].Name);
+			Assert.AreEqual (z2.Index, scope.Variables [2].Index);
+			Assert.AreEqual (nameof (z2), scope.Variables [2].Name);
+		}
+
+		[Test]
 		public void InsertVariableIndex ()
 		{
 			var object_ref = new TypeReference ("System", "Object", null, null, false);
@@ -103,6 +142,44 @@ namespace Mono.Cecil.Tests {
 			Assert.AreEqual (0, x.Index);
 			Assert.AreEqual (1, y.Index);
 			Assert.AreEqual (2, z.Index);
+		}
+
+		[Test]
+		public void InsertVariableWithDebugInfo ()
+		{
+			var object_ref = new TypeReference ("System", "Object", null, null, false);
+			var method = new MethodDefinition ("foo", MethodAttributes.Static, object_ref);
+			var body = new MethodBody (method);
+			var il = body.GetILProcessor ();
+			il.Emit (OpCodes.Ret);
+
+			var x = new VariableDefinition (object_ref);
+			var y = new VariableDefinition (object_ref);
+			var z = new VariableDefinition (object_ref);
+			var z2 = new VariableDefinition (object_ref);
+
+			body.Variables.Add (x);
+			body.Variables.Add (z);
+			body.Variables.Add (z2);
+
+			var scope = new ScopeDebugInformation (body.Instructions [0], body.Instructions [0]);
+			method.DebugInformation = new MethodDebugInformation (method) {
+				Scope = scope
+			};
+			scope.Variables.Add (new VariableDebugInformation (x.index, nameof (x)));
+			scope.Variables.Add (new VariableDebugInformation (z.index, nameof (z)));
+			scope.Variables.Add (new VariableDebugInformation (z2, nameof (z2)));
+
+			body.Variables.Insert (1, y);
+
+			// Adding local variable doesn't add debug info for it (since there's no way to deduce the name of the variable)
+			Assert.AreEqual (3, scope.Variables.Count);
+			Assert.AreEqual (x.Index, scope.Variables [0].Index);
+			Assert.AreEqual (nameof (x), scope.Variables [0].Name);
+			Assert.AreEqual (z.Index, scope.Variables [1].Index);
+			Assert.AreEqual (nameof (z), scope.Variables [1].Name);
+			Assert.AreEqual (z2.Index, scope.Variables [2].Index);
+			Assert.AreEqual (nameof (z2), scope.Variables [2].Name);
 		}
 	}
 }


### PR DESCRIPTION
When manipulating the local variables collection on a method body, automatically update the debug info for all affected local variables.

When removing a local variable, also remove the debug info for that local variable from the scopes.

When removing or inserting update the indices of local variable debug infos which are afected by the action. Note the local variable debug info either holds just a backpointer to the local variable in which case it doesn't store the index at all (and thus nothing to do), or it stores the index explicitly in which case it needs to be updated.

Added tests for both insert and remove cases.

Fixes #674 

/cc @marek-safar 