### PR TITLE
Auto update local scopes in debug info when manipulating instructions

### DIFF
--- a/Mono.Cecil.Cil/MethodBody.cs
+++ b/Mono.Cecil.Cil/MethodBody.cs
@@ -293,12 +293,12 @@ namespace Mono.Cecil.Cil {
 			//   - if the scope uses instruction reference to an instruction being removed - update it to remove the reference to the removed instruction
 			//   - if the scope uses any other instruction there's really no need to update it.
 			if ((!scope.Start.IsResolved && scope.Start.Offset >= startFromOffset) || 
-				(instructionRemoved != null && scope.Start.instruction == instructionRemoved))
+				(instructionRemoved != null && scope.Start.ResolvedInstruction == instructionRemoved))
 				scope.Start = new InstructionOffset (scope.Start.Offset + offset);
 
 			if (!scope.End.IsEndOfMethod && 
 				((!scope.End.IsResolved && scope.End.Offset >= startFromOffset) ||
-				 (instructionRemoved != null && scope.End.instruction == instructionRemoved)))
+				 (instructionRemoved != null && scope.End.ResolvedInstruction == instructionRemoved)))
 				scope.End = new InstructionOffset (scope.End.Offset + offset);
 
 			if (scope.HasScopes) {

--- a/Mono.Cecil.Cil/MethodBody.cs
+++ b/Mono.Cecil.Cil/MethodBody.cs
@@ -289,13 +289,17 @@ namespace Mono.Cecil.Cil {
 
 		static void UpdateLocalScope (ScopeDebugInformation scope, int startFromOffset, int offset, Instruction instructionRemoved)
 		{
-			// Only update scopes which use offsets and not instructions
-			//   - if the scope uses instruction reference to an instruction being removed - update it to remove the reference to the removed instruction
-			//   - if the scope uses any other instruction there's really no need to update it.
+			// For both start and enf offsets on the scope:
+			// * If the offset is resolved (points to instruction by reference)  only update it if the instruction it points to is being removed.
+			//   For non-removed instructions it remains correct regardless of any updates to the instructions.
+			// * If the offset is not resolved (stores the instruction offset number itself)
+			//   update the number accordingly to keep it pointing to the correct instruction (by offset).
+
 			if ((!scope.Start.IsResolved && scope.Start.Offset >= startFromOffset) || 
 				(instructionRemoved != null && scope.Start.ResolvedInstruction == instructionRemoved))
 				scope.Start = new InstructionOffset (scope.Start.Offset + offset);
 
+			// For end offset only update it if it's not the special sentinel value "EndOfMethod"; that should remain as-is.
 			if (!scope.End.IsEndOfMethod && 
 				((!scope.End.IsResolved && scope.End.Offset >= startFromOffset) ||
 				 (instructionRemoved != null && scope.End.ResolvedInstruction == instructionRemoved)))

--- a/Mono.Cecil.Cil/MethodBody.cs
+++ b/Mono.Cecil.Cil/MethodBody.cs
@@ -292,12 +292,12 @@ namespace Mono.Cecil.Cil {
 			// Only update scopes which use offsets and not instructions
 			//   - if the scope uses instruction reference to an instruction being removed - update it to remove the reference to the removed instruction
 			//   - if the scope uses any other instruction there's really no need to update it.
-			if ((scope.Start.instruction == null && scope.Start.Offset >= startFromOffset) || 
+			if ((!scope.Start.IsResolved && scope.Start.Offset >= startFromOffset) || 
 				(instructionRemoved != null && scope.Start.instruction == instructionRemoved))
 				scope.Start = new InstructionOffset (scope.Start.Offset + offset);
 
 			if (!scope.End.IsEndOfMethod && 
-				((scope.End.instruction == null && scope.End.Offset >= startFromOffset) ||
+				((!scope.End.IsResolved && scope.End.Offset >= startFromOffset) ||
 				 (instructionRemoved != null && scope.End.instruction == instructionRemoved)))
 				scope.End = new InstructionOffset (scope.End.Offset + offset);
 

--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -207,6 +207,8 @@ namespace Mono.Cecil.Cil {
 			get { return instruction == null && !offset.HasValue; }
 		}
 
+		internal bool IsResolved => instruction != null;
+
 		public InstructionOffset (Instruction instruction)
 		{
 			if (instruction == null)

--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -189,7 +189,7 @@ namespace Mono.Cecil.Cil {
 
 	public struct InstructionOffset {
 
-		readonly Instruction instruction;
+		internal readonly Instruction instruction;
 		readonly int? offset;
 
 		public int Offset {

--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -189,7 +189,7 @@ namespace Mono.Cecil.Cil {
 
 	public struct InstructionOffset {
 
-		internal readonly Instruction instruction;
+		readonly Instruction instruction;
 		readonly int? offset;
 
 		public int Offset {
@@ -208,6 +208,8 @@ namespace Mono.Cecil.Cil {
 		}
 
 		internal bool IsResolved => instruction != null;
+
+		internal Instruction ResolvedInstruction => instruction;
 
 		public InstructionOffset (Instruction instruction)
 		{

--- a/Test/Mono.Cecil.Tests/ILProcessorTests.cs
+++ b/Test/Mono.Cecil.Tests/ILProcessorTests.cs
@@ -67,6 +67,23 @@ namespace Mono.Cecil.Tests {
 		}
 
 		[Test]
+		public void InsertAfterWithLocalScopes ()
+		{
+			var method = CreateTestMethodWithLocalScopes ();
+			var il = method.GetILProcessor ();
+
+			il.InsertAfter (
+				0,
+				il.Create (OpCodes.Nop));
+
+			AssertOpCodeSequence (new [] { OpCodes.Ldloc_0, OpCodes.Nop, OpCodes.Ldloc_1, OpCodes.Ldloc_2 }, method);
+			var wholeBodyScope = VerifyWholeBodyScope (method);
+			AssertLocalScope (wholeBodyScope.Scopes [0], 0, 2);
+			AssertLocalScope (wholeBodyScope.Scopes [1], 2, 3);
+			AssertLocalScope (wholeBodyScope.Scopes [2], 3, null);
+		}
+
+		[Test]
 		public void ReplaceUsingIndex ()
 		{
 			var method = CreateTestMethod (OpCodes.Ldloc_0, OpCodes.Ldloc_2, OpCodes.Ldloc_3);
@@ -75,6 +92,24 @@ namespace Mono.Cecil.Tests {
 			il.Replace (1, il.Create (OpCodes.Nop));
 
 			AssertOpCodeSequence (new [] { OpCodes.Ldloc_0, OpCodes.Nop, OpCodes.Ldloc_3 }, method);
+		}
+
+		[Test]
+		public void ReplaceWithLocalScopes ()
+		{
+			var method = CreateTestMethodWithLocalScopes ();
+			var il = method.GetILProcessor ();
+
+			// Replace with larger instruction
+			var instruction = il.Create (OpCodes.Ldstr, "test");
+			instruction.Offset = method.Instructions [1].Offset;
+			il.Replace (1, instruction);
+
+			AssertOpCodeSequence (new [] { OpCodes.Ldloc_0, OpCodes.Ldstr, OpCodes.Ldloc_2 }, method);
+			var wholeBodyScope = VerifyWholeBodyScope (method);
+			AssertLocalScope (wholeBodyScope.Scopes [0], 0, 1);
+			AssertLocalScope (wholeBodyScope.Scopes [1], 1, 6); // size of the new instruction is 5 bytes
+			AssertLocalScope (wholeBodyScope.Scopes [2], 6, null);
 		}
 
 		[Test]
@@ -108,7 +143,70 @@ namespace Mono.Cecil.Tests {
 			foreach (var opcode in opcodes)
 				il.Emit (opcode);
 
+			var instructions = method.Body.Instructions;
+			int size = 0;
+			for (int i = 0; i < instructions.Count; i++) {
+				var instruction = instructions [i];
+				instruction.Offset = size;
+				size += instruction.GetSize ();
+			}
+
 			return method.Body;
+		}
+
+		static ScopeDebugInformation VerifyWholeBodyScope (MethodBody body)
+		{
+			var debug_info = body.Method.DebugInformation;
+			Assert.IsNotNull (debug_info);
+			AssertLocalScope (debug_info.Scope, 0, null);
+			return debug_info.Scope;
+		}
+
+		static void AssertLocalScope (ScopeDebugInformation scope, int startOffset, int? endOffset)
+		{
+			Assert.IsNotNull (scope);
+			Assert.AreEqual (startOffset, scope.Start.Offset);
+			if (endOffset.HasValue)
+				Assert.AreEqual (endOffset.Value, scope.End.Offset);
+			else
+				Assert.IsTrue (scope.End.IsEndOfMethod);
+		}
+
+		static MethodBody CreateTestMethodWithLocalScopes ()
+		{
+			var methodBody = CreateTestMethod (OpCodes.Ldloc_0, OpCodes.Ldloc_1, OpCodes.Ldloc_2);
+			var method = methodBody.Method;
+			var debug_info = method.DebugInformation;
+
+			var wholeBodyScope = new ScopeDebugInformation () {
+				Start = new InstructionOffset (0),
+				End = new InstructionOffset ()
+			};
+			int size = 0;
+			var instruction = methodBody.Instructions [0];
+			var innerScopeBegining = new ScopeDebugInformation () { 
+				Start = new InstructionOffset (size), 
+				End = new InstructionOffset (size + instruction.GetSize ())
+			};
+			size += instruction.GetSize ();
+			wholeBodyScope.Scopes.Add (innerScopeBegining);
+
+			instruction = methodBody.Instructions [1];
+			var innerScopeMiddle = new ScopeDebugInformation () {
+				Start = new InstructionOffset (size),
+				End = new InstructionOffset (size + instruction.GetSize ())
+			};
+			size += instruction.GetSize ();
+			wholeBodyScope.Scopes.Add (innerScopeMiddle);
+
+			var innerScopeEnd = new ScopeDebugInformation () {
+				Start = new InstructionOffset (size),
+				End = new InstructionOffset ()
+			};
+			wholeBodyScope.Scopes.Add (innerScopeEnd);
+
+			debug_info.Scope = wholeBodyScope;
+			return methodBody;
 		}
 	}
 }


### PR DESCRIPTION
Before this change Cecil would not update local scopes when manipulating method bodies. This can lead to corrupted debug info - which when written to a PDB results in corrupted PDB.

Cecil can store local scopes in two ways:
* Using IL offset numbers - this is how pretty much all of the symbol readers populate the OMs.
* Using references to instructions.

If the local scopes use offset values this change will update the local scopes for all insert and remove operations on the method body. The behaviors for insert is basically "insert after" in that the new instruction is added to the scopes of the previous instruction.

If the local scopes are using instructions directly the change only removes any references to instructions which are being removed from the method body (and replaces them with the instruction offset value).

To be able to tell the difference between these cases the `instruction` field has been made internal in the `InstructionOffset` structure.

Fixes #675.