### PR TITLE
Add some helper method to help instantiate generic types and methods

### DIFF
--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -854,6 +854,106 @@ namespace Mono.Cecil {
 			return MetadataImporter.ImportReference (type, context);
 		}
 
+		/// <summary>
+		/// Create a GenericInstanceType for the given generic type instantiated with the given generic arguments.
+		/// </summary>
+		/// <param name="genericType">The generic type to instantiate.</param>
+		/// <param name="genericArgs">The generic arguments needed to instantiate the generic type.</param>
+		/// <returns></returns>
+		public GenericInstanceType ImportGenericTypeInstance (TypeReference genericType, params TypeReference [] genericArgs)
+		{
+			TypeReference typeDef = genericType.Resolve ();
+			if (!typeDef.HasGenericParameters) {
+				throw new InvalidOperationException (string.Format ("Type {0} is not generic", genericType));
+			}
+
+			typeDef = this.ImportReference (typeDef);
+			var instance = new GenericInstanceType (typeDef);
+			for (int i = 0; i < typeDef.GenericParameters.Count; i++) {
+				var p = typeDef.GenericParameters [i];
+				if (p.Position < genericArgs.Length) {
+					GenericParameter parameter = new GenericParameter (p.Name, typeDef);
+					instance.GenericParameters.Add (parameter);
+					instance.GenericArguments.Add (genericArgs [p.Position]);
+				} else {
+					throw new InvalidOperationException (string.Format ("Not enough generic arguments to instantiate type {0}", genericType));
+				}
+			}
+
+			return instance;
+		}
+
+		/// <summary>
+		/// Create a GenericInstanceMethod from the given generic method and the given generic arguments.
+		/// Note: this can also handle the case where the DeclaringType is also generic.  Simply pass the combined
+		/// generic args for the declaring type and the method.
+		/// </summary>
+		/// <param name="genericMethod">A generic method to instantiate.</param>
+		/// <param name="genericArgs">The combined generic arguments for the declaring type (if it is generic) and for the method.</param>
+		/// <returns></returns>
+		public MethodReference ImportGenericMethodInstance (MethodReference genericMethod, params TypeReference [] genericArgs)
+		{
+			var methodDef = genericMethod.Resolve ();
+
+			TypeReference typeDef = methodDef.DeclaringType;
+			var genericArgOffset = 0;
+			GenericInstanceType typeInstance = null;
+
+			if (typeDef.HasGenericParameters) {
+				typeInstance = this.ImportGenericTypeInstance (typeDef, genericArgs);
+				typeDef = typeInstance;
+				genericArgOffset = typeInstance.GenericArguments.Count;
+			}
+
+			TypeReference returnType = methodDef.ReturnType;
+
+			// create a new MethodReference with the instantiated generic type as the DeclaringType.
+			MethodReference result = new MethodReference (genericMethod.Name, returnType, typeDef) {
+				HasThis = genericMethod.HasThis,
+				ExplicitThis = genericMethod.ExplicitThis,
+				CallingConvention = genericMethod.CallingConvention
+			};
+
+			GenericInstanceMethod genericMethodInstance = null;
+
+			if (methodDef.HasGenericParameters) {
+				// Then we also need to instantiate the generic method!
+				genericMethodInstance = new GenericInstanceMethod (result);
+
+				for (int i = 0; i < methodDef.GenericParameters.Count; i++) {
+					var p = methodDef.GenericParameters [i];
+					var j = p.Position + genericArgOffset;
+					if (j > genericArgs.Length) {
+						throw new InvalidOperationException (string.Format ("Not enough generic arguments to instantiate method {0}", genericMethod));
+					}
+
+					GenericParameter parameter = new GenericParameter (p.Name, genericMethodInstance);
+					result.GenericParameters.Add (parameter);
+					genericMethodInstance.GenericParameters.Add (parameter);
+					genericMethodInstance.GenericArguments.Add (genericArgs [j]);
+				}
+
+				result = genericMethodInstance;
+			}
+
+			foreach (var arg in genericMethod.Parameters) {
+				ParameterDefinition p = new ParameterDefinition (arg.Name, arg.Attributes,
+						   this.ImportReference (arg.ParameterType, typeDef));
+
+				if (arg.ParameterType is GenericParameter gp) {
+					if (gp.DeclaringType != null) {
+						p.ParameterType = typeInstance.GenericParameters [gp.Position];
+					} else if (gp.DeclaringMethod != null) {
+						p.ParameterType = genericMethodInstance.GenericParameters [gp.Position];
+					}
+				}
+
+				result.Parameters.Add (p);
+			}
+
+			return result;
+		}
+
 		[Obsolete ("Use ImportReference", error: false)]
 		public FieldReference Import (FieldReference field)
 		{


### PR DESCRIPTION
Turns out instantiating a generic type or method is non-trivial if you want the newly written assembly to actually work properly. I found these helper methods useful, perhaps others would also.  I wasn't sure where the best place to test these helpers would be, do you have any "read/modify/write" assembly tests ?  That's the scenario where I found these new helpers to be useful.  Actually, we'd want tests that "read/modify/write/execute" to verify the updated assembly loads and runs properly.  For example, suppose my assembly contains this generic class:
```c#
    class Foo<T>
    {
        public static void Bar<U>(T x, U y)
        {
            Console.WriteLine("Hey this is even more fun: {0}, {1}", x, y);
        }
    }
```
and i want to read the assembly and add a call to Bar, then write it back out.  I can now do this:
```c#
var fooType = module.GetType("HelloWorld.Foo`1");
var barMethod = (from m in fooType.Methods where m.Name == "Bar" select m).FirstOrDefault();
var intType = module.ImportReference(typeof(int));

// instantiate Foo<int>.Bar<int>(int x, int y)
var instance = module.ImportGenericMethodInstance(barMethod, intType, intType);
    
// now add call to the method with two constant integer values 10 and 20
// in a test method somewhere:
MethodDefinition testMethod = ... 
var processor = testMethod.Body.GetILProcessor();
var loadint = Instruction.Create(OpCodes.Ldc_I4, 10);
processor.InsertBefore(testMethod.Body.Instructions[0], loadint);
var loadsecondInt = Instruction.Create(OpCodes.Ldc_I4, 20);
processor.InsertAfter(loadint, loadsecondInt);
var callBar = Instruction.Create(OpCodes.Call, instance);
processor.InsertAfter(loadsecondInt, callBar);

// now I can write out the modified assembly and it works.
```