### PR TITLE
Fix MdbWriter to produce the correct MVID in case deterministic output is required

### DIFF
--- a/symbols/mdb/Mono.Cecil.Mdb/MdbWriter.cs
+++ b/symbols/mdb/Mono.Cecil.Mdb/MdbWriter.cs
@@ -25,7 +25,7 @@ namespace Mono.Cecil.Mdb {
 			Mixin.CheckModule (module);
 			Mixin.CheckFileName (fileName);
 
-			return new MdbWriter (module.Mvid, fileName);
+			return new MdbWriter (module, fileName);
 		}
 
 		public ISymbolWriter GetSymbolWriter (ModuleDefinition module, Stream symbolStream)
@@ -36,13 +36,13 @@ namespace Mono.Cecil.Mdb {
 
 	public sealed class MdbWriter : ISymbolWriter {
 
-		readonly Guid mvid;
+		readonly ModuleDefinition module;
 		readonly MonoSymbolWriter writer;
 		readonly Dictionary<string, SourceFile> source_files;
 
-		public MdbWriter (Guid mvid, string assembly)
+		public MdbWriter (ModuleDefinition module, string assembly)
 		{
-			this.mvid = mvid;
+			this.module = module;
 			this.writer = new MonoSymbolWriter (assembly);
 			this.source_files = new Dictionary<string, SourceFile> ();
 		}
@@ -169,7 +169,7 @@ namespace Mono.Cecil.Mdb {
 
 		public void Dispose ()
 		{
-			writer.WriteSymbolFile (mvid);
+			writer.WriteSymbolFile (module.Mvid);
 		}
 
 		class SourceFile : ISourceFile {

--- a/symbols/mdb/Test/Mono.Cecil.Tests/MdbTests.cs
+++ b/symbols/mdb/Test/Mono.Cecil.Tests/MdbTests.cs
@@ -1,6 +1,8 @@
+using Mono.Cecil.Cil;
 using Mono.Cecil.Mdb;
 
 using NUnit.Framework;
+using System.IO;
 
 namespace Mono.Cecil.Tests {
 
@@ -79,6 +81,20 @@ namespace Mono.Cecil.Tests {
 					Assert.AreEqual(@"C:\tmp\repropartial\BreakpointTest.Portable\TestService.cs", sp.Document.Url);
 
 			}, symbolReaderProvider: typeof(MdbReaderProvider), symbolWriterProvider: typeof(MdbWriterProvider));
+		}
+
+		[Test]
+		public void WriteAndReadAgainModuleWithDeterministicMvid ()
+		{
+			const string resource = "simplemdb.exe";
+			string destination = Path.GetTempFileName ();
+
+			using (var module = GetResourceModule (resource, new ReaderParameters { SymbolReaderProvider = new DefaultSymbolReaderProvider (true) })) {
+				module.Write (destination, new WriterParameters { WriteSymbols = true, DeterministicMvid = true });
+			}
+
+			using (var module = ModuleDefinition.ReadModule (destination, new ReaderParameters { SymbolReaderProvider = new DefaultSymbolReaderProvider (true) })) {
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/jbevain/cecil/issues/680.

The MdbWriter must not cache the MVID upon writer construction, but it needs to get it only after it was computed - so basically only when it's about to actually write.