### PR TITLE
Replace licenseUrl with SPDX license identifier (minor issue)

### DIFF
--- a/Mono.Cecil.nuspec
+++ b/Mono.Cecil.nuspec
@@ -6,7 +6,7 @@
     <title>Mono.Cecil</title>
     <authors>Jb Evain</authors>
     <owners>Jb Evain</owners>
-    <licenseUrl>http://opensource.org/licenses/mit-license.php</licenseUrl>
+    <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectUrl>http://github.com/jbevain/cecil/</projectUrl>
     <summary>Cecil is a library written by Jb Evain to generate and inspect programs and libraries in the ECMA CIL format.</summary>


### PR DESCRIPTION
Because licenseUrl is going to be deprecated, replace it with the SPDX license identifier for the identical MIT license.

The [Microsoft documentation](https://docs.microsoft.com/en-us/nuget/reference/nuspec#license) recommends this approach.

This is related to issue https://github.com/jbevain/cecil/issues/699 , which I created.

Before this PR:
```
PS C:\Users\gdynamics\source\repos\cecil> nuget.exe pack Mono.Cecil.nuspec
Attempting to build package from 'Mono.Cecil.nuspec'.
WARNING: NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.
Successfully created package 'C:\Users\gdynamics\source\repos\cecil\Mono.Cecil.0.11.3.nupkg'.
```

After:
```
PS C:\Users\gdynamics\source\repos\cecil> nuget pack Mono.Cecil.nuspec
Attempting to build package from 'Mono.Cecil.nuspec'.
Successfully created package 'C:\Users\gdynamics\source\repos\cecil\Mono.Cecil.0.11.3.nupkg'.
```
