### PR TITLE
Add ModuleDefinition.ImmediateRead

### DIFF
--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -921,6 +921,15 @@ namespace Mono.Cecil {
 		{
 			return Read (token, (t, reader) => reader.LookupToken (t));
 		}
+		
+		public void ImmediateRead ()
+		{
+			if (!HasImage)
+				return;
+			ReadingMode = ReadingMode.Immediate;
+			var moduleReader = new ImmediateModuleReader (Image);
+			moduleReader.ReadModule (this, resolve_attributes: true);
+		}
 
 		readonly object module_lock = new object();
 

--- a/Test/Mono.Cecil.Tests/ModuleTests.cs
+++ b/Test/Mono.Cecil.Tests/ModuleTests.cs
@@ -277,6 +277,27 @@ namespace Mono.Cecil.Tests {
 			}
 		}
 
+		
+		[Test]
+		public void OpenModuleDeferredAndThenPerformImmediateRead ()
+		{
+			using (var module = GetResourceModule ("hello.exe", ReadingMode.Deferred)) {
+				Assert.AreEqual (ReadingMode.Deferred, module.ReadingMode);
+				module.ImmediateRead ();
+				Assert.AreEqual (ReadingMode.Immediate, module.ReadingMode);
+			}
+		}
+		
+		[Test]
+		public void ImmediateReadDoesNothingForModuleWithNoImage ()
+		{
+			using (var module = new ModuleDefinition ()) {
+				var initialReadingMode = module.ReadingMode;
+				module.ImmediateRead ();
+				Assert.AreEqual (initialReadingMode, module.ReadingMode);
+			}
+		}
+
 		[Test]
 		public void OwnedStreamModuleFileName ()
 		{


### PR DESCRIPTION
We are going to use this to do a multi stage load in parallel.  We will be able to greatly reduce our load times using this new API.  The way it's going to work is

Stage 1 - In parallel, load the assemblies with ReadingMode.Deferred.
Stage 2 - Populate our AssemblyResolver with a cache of all read assemblies.
Stage 3 - In parallel, call ImmediateRead.

What I really want is an API to load everything in stage 3.  I found that ImmediateRead does not load method bodies.  I don't know if/how you want want something like this exposed via the public API.  For now I'm iterating the data model and forcing things to load that ImmediateRead did not cover.
