### PR TITLE
revert layout change

### DIFF
--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1435,7 +1435,27 @@ namespace Mono.Cecil {
 			if (type.HasInterfaces)
 				AddInterfaces (type);
 
-			AddLayoutInfo (type);
+			if (type.HasLayoutInfo)
+				AddLayoutInfo (type);
+			else
+			if (type.IsValueType)
+			{
+				var no_instance_fields = !type.HasFields;
+				if (!no_instance_fields)
+				{
+					var fields = type.Fields;
+
+					for (int i = 0; i < fields.Count; i++)
+						if (!fields [i].IsStatic)
+						{
+							no_instance_fields = false;
+							break;
+						}
+				}
+
+				if (no_instance_fields)
+					GetTable<ClassLayoutTable> (Table.ClassLayout).AddRow (new ClassLayoutRow (0, 1, type.token.RID));
+			}
 
 			if (type.HasFields)
 				AddFields (type);
@@ -1554,36 +1574,12 @@ namespace Mono.Cecil {
 
 		void AddLayoutInfo (TypeDefinition type)
 		{
-			if (type.HasLayoutInfo) {
-				var table = GetTable<ClassLayoutTable> (Table.ClassLayout);
+			var table = GetTable<ClassLayoutTable> (Table.ClassLayout);
 
-				table.AddRow (new ClassLayoutRow (
-					(ushort) type.PackingSize,
-					(uint) type.ClassSize,
-					type.token.RID));
-
-				return;
-			}
-
-			if (type.IsValueType && HasNoInstanceField (type)) {
-				var table = GetTable<ClassLayoutTable> (Table.ClassLayout);
-
-				table.AddRow (new ClassLayoutRow (0, 1, type.token.RID));
-			}
-		}
-
-		static bool HasNoInstanceField (TypeDefinition type)
-		{
-			if (!type.HasFields)
-				return true;
-
-			var fields = type.Fields;
-
-			for (int i = 0; i < fields.Count; i++)
-				if (!fields [i].IsStatic)
-					return false;
-
-			return true;
+			table.AddRow (new ClassLayoutRow (
+				(ushort) type.PackingSize,
+				(uint) type.ClassSize,
+				type.token.RID));
 		}
 
 		void AddNestedTypes (TypeDefinition type)

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1437,25 +1437,6 @@ namespace Mono.Cecil {
 
 			if (type.HasLayoutInfo)
 				AddLayoutInfo (type);
-			else
-			if (type.IsValueType)
-			{
-				var no_instance_fields = !type.HasFields;
-				if (!no_instance_fields)
-				{
-					var fields = type.Fields;
-
-					for (int i = 0; i < fields.Count; i++)
-						if (!fields [i].IsStatic)
-						{
-							no_instance_fields = false;
-							break;
-						}
-				}
-
-				if (no_instance_fields)
-					GetTable<ClassLayoutTable> (Table.ClassLayout).AddRow (new ClassLayoutRow (0, 1, type.token.RID));
-			}
 
 			if (type.HasFields)
 				AddFields (type);

--- a/Test/Mono.Cecil.Tests/TypeTests.cs
+++ b/Test/Mono.Cecil.Tests/TypeTests.cs
@@ -31,19 +31,6 @@ namespace Mono.Cecil.Tests {
 		}
 
 		[Test]
-		public void EmptyStructLayout ()
-		{
-			TestModule ("hello.exe", module =>
-			{
-				var foo = new TypeDefinition ("", "Foo",
-					TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit | TypeAttributes.SequentialLayout,
-					module.ImportReference (typeof (ValueType))) ;
-
-				module.Types.Add (foo) ;
-			}) ;
-		}
-
-		[Test]
 		public void SimpleInterfaces ()
 		{
 			TestIL ("types.il", module => {


### PR DESCRIPTION
https://github.com/jbevain/cecil/pull/504 seems incorrect.  Roslyn does not add a table entry for value types with no instance fields.  The result of that PR is that opening an assembly with cecil, writing it back out, and then reading it in again results in different values returned from `TypeDefinition.PackingSize` and `TypeDefinition.ClassSize`.  Even if the new values of `0` and `1` are harmless, it doesn't seem like a good idea to have cecil deviate from Roslyn's behavior.