### PR TITLE
Add support for generating the method and generic method comment signature with nested types

### DIFF
--- a/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
+++ b/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
@@ -98,14 +98,14 @@ namespace N
         /// </summary>
         public static explicit operator int(X x) { return 1; }
 
-		public static void Linq (IEnumerable<string> enumerable, Func<string> selector)
-		{
-		}
+	    public static void Linq (IEnumerable<string> enumerable, Func<string> selector)
+	    {
+	    }
 
-		/// <summary>
+        /// <summary>
 		/// ID string generated is "M:N.X.N#IX{N#KVP{System#String,System#Int32}}#IXA(N.KVP{System.String,System.Int32})"
-		/// </summary>
-		void IX<KVP<string, int>>.IXA (KVP<string, int> k) { }
+        /// </summary>
+        void IX<KVP<string, int>>.IXA (KVP<string, int> k) { }
 	}
 
 	public interface IX<K>

--- a/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
+++ b/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
@@ -98,17 +98,15 @@ namespace N
         /// </summary>
         public static explicit operator int(X x) { return 1; }
 
-
 		public static void Linq (IEnumerable<string> enumerable, Func<string> selector)
 		{
 		}
-
 
 		/// <summary>
 		/// ID string generated is "M:N.X.N#IX{N#KVP{System#String,System#Int32}}#IXA(N.KVP{System.String,System.Int32})"
 		/// </summary>
 		void IX<KVP<string, int>>.IXA (KVP<string, int> k) { }
-    }
+	}
 
 	public interface IX<K>
 	{

--- a/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
+++ b/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
@@ -157,31 +157,31 @@ namespace N
 	{
 		public class NestedType { }
 
-		public class NestedGenericType<NT> {
+		public class NestedGenericType<TNested> {
 			public class NestedType { }
 
 			/// <summary>
 			/// ID string generated is "M:N.GenericType`1.NestedGenericType`1.WithTypeParameterOfGenericMethod``1(System.Collections.Generic.List{``0})"
 			/// </summary>
-			public void WithTypeParameterOfGenericMethod<GT> (List<GT> list) { }
+			public void WithTypeParameterOfGenericMethod<TMethod> (List<TMethod> list) { }
 
 
 			/// <summary>
 			/// ID string generated is "M:N.GenericType`1.NestedGenericType`1.WithTypeParameterOfGenericType(System.Collections.Generic.Dictionary{`0,`1})"
 			/// </summary>
-			public void WithTypeParameterOfGenericType (Dictionary<T, NT> dict) { }
+			public void WithTypeParameterOfGenericType (Dictionary<T, TNested> dict) { }
 
 
 			/// <summary>
 			/// ID string generated is "M:N.GenericType`1.NestedGenericType`1.WithTypeParameterOfGenericType``1(System.Collections.Generic.List{`1})"
 			/// </summary>
-			public void WithTypeParameterOfNestedGenericType<GT> (List<NT> list) { }
+			public void WithTypeParameterOfNestedGenericType<TMethod> (List<TNested> list) { }
 
 
 			/// <summary>
 			/// ID string generated is "M:N.GenericType`1.NestedGenericType`1.WithTypeParameterOfGenericTypeAndGenericMethod``1(System.Collections.Generic.Dictionary{`1,``0})"
 			/// </summary>
-			public void WithTypeParameterOfGenericTypeAndGenericMethod<GT> (Dictionary<NT, GT> dict) { }
+			public void WithTypeParameterOfGenericTypeAndGenericMethod<TMethod> (Dictionary<TNested, TMethod> dict) { }
 		}
 	}
 }

--- a/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
+++ b/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
@@ -167,7 +167,7 @@ namespace N
 
 
 			/// <summary>
-			/// 
+			/// ID string generated is "M:N.GenericType`1.NestedGenericType`1.WithTypeParameterOfGenericType(System.Collections.Generic.Dictionary{`0,`1})"
 			/// </summary>
 			public void WithTypeParameterOfGenericType (Dictionary<T, NT> dict) { }
 

--- a/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
+++ b/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
@@ -1,79 +1,77 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using NUnit.Framework;
-
 using Mono.Cecil.Rocks;
 
 namespace N
 {
 
-    /// <summary>
-    /// ID string generated is "T:N.X". 
-    /// </summary>
-    public class X : IX<KVP<string, int>>
-    {
-        /// <summary>
-        /// ID string generated is "M:N.X.#ctor".
-        /// </summary>
-        public X() { }
+	/// <summary>
+	/// ID string generated is "T:N.X". 
+	/// </summary>
+	public class X : IX<KVP<string, int>>
+	{
+		/// <summary>
+		/// ID string generated is "M:N.X.#ctor".
+		/// </summary>
+		public X() { }
 
 
-        /// <summary>
-        /// ID string generated is "M:N.X.#ctor(System.Int32)".
-        /// </summary>
-        /// <param name="i">Describe parameter.</param>
-        public X(int i) { }
+		/// <summary>
+		/// ID string generated is "M:N.X.#ctor(System.Int32)".
+		/// </summary>
+		/// <param name="i">Describe parameter.</param>
+		public X(int i) { }
 
 
-        /// <summary>
-        /// ID string generated is "F:N.X.q".
-        /// </summary>
-        public string q;
+		/// <summary>
+		/// ID string generated is "F:N.X.q".
+		/// </summary>
+		public string q;
 
 
-        /// <summary>
-        /// ID string generated is "F:N.X.PI".
-        /// </summary>
-        public const double PI = 3.14;
+		/// <summary>
+		/// ID string generated is "F:N.X.PI".
+		/// </summary>
+		public const double PI = 3.14;
 
 
-        /// <summary>
-        /// ID string generated is "M:N.X.f".
-        /// </summary>
-        public int f() { return 1; }
+		/// <summary>
+		/// ID string generated is "M:N.X.f".
+		/// </summary>
+		public int f() { return 1; }
 
 
-        /// <summary>
-        /// ID string generated is "M:N.X.bb(System.String,System.Int32@)".
-        /// </summary>
-        public int bb(string s, ref int y) { return 1; }
+		/// <summary>
+		/// ID string generated is "M:N.X.bb(System.String,System.Int32@)".
+		/// </summary>
+		public int bb(string s, ref int y) { return 1; }
 
 
-        /// <summary>
-        /// ID string generated is "M:N.X.gg(System.Int16[],System.Int32[0:,0:])". 
-        /// </summary>
-        public int gg(short[] array1, int[,] array) { return 0; }
+		/// <summary>
+		/// ID string generated is "M:N.X.gg(System.Int16[],System.Int32[0:,0:])". 
+		/// </summary>
+		public int gg(short[] array1, int[,] array) { return 0; }
 
 
-        /// <summary>
-        /// ID string generated is "M:N.X.op_Addition(N.X,N.X)". 
-        /// </summary>
-        public static X operator +(X x, X xx) { return x; }
+		/// <summary>
+		/// ID string generated is "M:N.X.op_Addition(N.X,N.X)". 
+		/// </summary>
+		public static X operator +(X x, X xx) { return x; }
 
 
-        /// <summary>
-        /// ID string generated is "P:N.X.prop".
-        /// </summary>
-        public int prop { get { return 1; } set { } }
+		/// <summary>
+		/// ID string generated is "P:N.X.prop".
+		/// </summary>
+		public int prop { get { return 1; } set { } }
 
 
-        /// <summary>
-        /// ID string generated is "E:N.X.d".
-        /// </summary>
+		/// <summary>
+		/// ID string generated is "E:N.X.d".
+		/// </summary>
 #pragma warning disable 67
-        public event D d;
+		public event D d;
 #pragma warning restore 67
 
 
@@ -83,32 +81,32 @@ namespace N
 		public int this[string s] { get { return 1; } }
 
 
-        /// <summary>
-        /// ID string generated is "T:N.X.Nested".
-        /// </summary>
-        public class Nested { }
+		/// <summary>
+		/// ID string generated is "T:N.X.Nested".
+		/// </summary>
+		public class Nested { }
 
 
-        /// <summary>
-        /// ID string generated is "T:N.X.D". 
-        /// </summary>
-        public delegate void D(int i);
+		/// <summary>
+		/// ID string generated is "T:N.X.D". 
+		/// </summary>
+		public delegate void D(int i);
 
 
-        /// <summary>
-        /// ID string generated is "M:N.X.op_Explicit(N.X)~System.Int32".
-        /// </summary>
-        public static explicit operator int(X x) { return 1; }
+		/// <summary>
+		/// ID string generated is "M:N.X.op_Explicit(N.X)~System.Int32".
+		/// </summary>
+		public static explicit operator int(X x) { return 1; }
 
-	    public static void Linq (IEnumerable<string> enumerable, Func<string> selector)
-	    {
-	    }
 
-        /// <summary>
+		public static void Linq (IEnumerable<string> enumerable, Func<string> selector) { }
+
+
+		/// <summary>
 		/// ID string generated is "M:N.X.N#IX{N#KVP{System#String,System#Int32}}#IXA(N.KVP{System.String,System.Int32})"
-        /// </summary>
-        void IX<KVP<string, int>>.IXA (KVP<string, int> k) { }
-    }
+		/// </summary>
+		void IX<KVP<string, int>>.IXA (KVP<string, int> k) { }
+	}
 
 	public interface IX<K>
 	{
@@ -116,6 +114,76 @@ namespace N
 	}
 
 	public class KVP<K, T> { }
+
+	public class GenericMethod
+	{
+		/// <summary>
+		/// ID string generated is "M:N.GenericMethod.WithNestedType``1(N.GenericType{``0}.NestedType)".
+		/// </summary>
+		public void WithNestedType<T> (GenericType<T>.NestedType nestedType) { }
+
+
+		/// <summary>
+		/// ID string generated is "M:N.GenericMethod.WithIntOfNestedType``1(N.GenericType{System.Int32}.NestedType)".
+		/// </summary>
+		public void WithIntOfNestedType<T> (GenericType<int>.NestedType nestedType) { }
+
+
+		/// <summary>
+		/// ID string generated is "M:N.GenericMethod.WithNestedGenericType``1(N.GenericType{``0}.NestedGenericType{``0}.NestedType)".
+		/// </summary>
+		public void WithNestedGenericType<T> (GenericType<T>.NestedGenericType<T>.NestedType nestedType) { }
+
+
+		/// <summary>
+		/// ID string generated is "M:N.GenericMethod.WithIntOfNestedGenericType``1(N.GenericType{System.Int32}.NestedGenericType{System.Int32}.NestedType)".
+		/// </summary>
+		public void WithIntOfNestedGenericType<T> (GenericType<int>.NestedGenericType<int>.NestedType nestedType) { }
+
+
+		/// <summary>
+		/// ID string generated is "M:N.GenericMethod.WithMultipleTypeParameterAndNestedGenericType``2(N.GenericType{``0}.NestedGenericType{``1}.NestedType)".
+		/// </summary>
+		public void WithMultipleTypeParameterAndNestedGenericType<T1, T2> (GenericType<T1>.NestedGenericType<T2>.NestedType nestedType) { }
+
+
+		/// <summary>
+		/// ID string generated is "M:N.GenericMethod.WithMultipleTypeParameterAndIntOfNestedGenericType``2(N.GenericType{System.Int32}.NestedGenericType{System.Int32}.NestedType)".
+		/// </summary>
+		public void WithMultipleTypeParameterAndIntOfNestedGenericType<T1, T2> (GenericType<int>.NestedGenericType<int>.NestedType nestedType) { }
+	}
+
+	public class GenericType<T>
+	{
+		public class NestedType { }
+
+		public class NestedGenericType<NT> {
+			public class NestedType { }
+
+			/// <summary>
+			/// ID string generated is "M:N.GenericType`1.NestedGenericType`1.WithTypeParameterOfGenericMethod``1(System.Collections.Generic.List{``0})"
+			/// </summary>
+			public void WithTypeParameterOfGenericMethod<GT> (List<GT> list) { }
+
+
+			/// <summary>
+			/// 
+			/// </summary>
+			public void WithTypeParameterOfGenericType (Dictionary<T, NT> dict) { }
+
+
+			/// <summary>
+			/// ID string generated is "M:N.GenericType`1.NestedGenericType`1.WithTypeParameterOfGenericType``1(System.Collections.Generic.List{`1})"
+			/// </summary>
+			public void WithTypeParameterOfNestedGenericType<GT> (List<NT> list) { }
+
+
+			/// <summary>
+			/// ID string generated is "M:N.GenericType`1.NestedGenericType`1.WithTypeParameterOfGenericTypeAndGenericMethod``1(System.Collections.Generic.Dictionary{`1,``0})"
+			/// </summary>
+			public void WithTypeParameterOfGenericTypeAndGenericMethod<GT> (Dictionary<NT, GT> dict) { }
+		}
+	}
 }
 
 namespace Mono.Cecil.Tests {
@@ -182,7 +250,7 @@ namespace Mono.Cecil.Tests {
 
 			AssertDocumentID ("M:N.X.bb(System.String,System.Int32@)", method);
 		}
-		
+
 		[Test]
 		public void MethodWithArrayParameters ()
 		{
@@ -190,6 +258,32 @@ namespace Mono.Cecil.Tests {
 			var method = type.Methods.Single (m => m.Name == "gg");
 
 			AssertDocumentID ("M:N.X.gg(System.Int16[],System.Int32[0:,0:])", method);
+		}
+
+		[TestCase ("WithNestedType", "WithNestedType``1(N.GenericType{``0}.NestedType)")]
+		[TestCase ("WithIntOfNestedType", "WithIntOfNestedType``1(N.GenericType{System.Int32}.NestedType)")]
+		[TestCase ("WithNestedGenericType", "WithNestedGenericType``1(N.GenericType{``0}.NestedGenericType{``0}.NestedType)")]
+		[TestCase ("WithIntOfNestedGenericType", "WithIntOfNestedGenericType``1(N.GenericType{System.Int32}.NestedGenericType{System.Int32}.NestedType)")]
+		[TestCase ("WithMultipleTypeParameterAndNestedGenericType", "WithMultipleTypeParameterAndNestedGenericType``2(N.GenericType{``0}.NestedGenericType{``1}.NestedType)")]
+		[TestCase ("WithMultipleTypeParameterAndIntOfNestedGenericType", "WithMultipleTypeParameterAndIntOfNestedGenericType``2(N.GenericType{System.Int32}.NestedGenericType{System.Int32}.NestedType)")]
+		public void GenericMethodWithNestedTypeParameters (string methodName, string docCommentId)
+		{
+			var type = GetTestType (typeof (N.GenericMethod));
+			var method = type.Methods.Single (m => m.Name == methodName);
+
+			AssertDocumentID ($"M:N.GenericMethod.{docCommentId}", method);
+		}
+
+		[TestCase ("WithTypeParameterOfGenericMethod", "WithTypeParameterOfGenericMethod``1(System.Collections.Generic.List{``0})")]
+		[TestCase ("WithTypeParameterOfGenericType", "WithTypeParameterOfGenericType(System.Collections.Generic.Dictionary{`0,`1})")]
+		[TestCase ("WithTypeParameterOfNestedGenericType", "WithTypeParameterOfNestedGenericType``1(System.Collections.Generic.List{`1})")]
+		[TestCase ("WithTypeParameterOfGenericTypeAndGenericMethod", "WithTypeParameterOfGenericTypeAndGenericMethod``1(System.Collections.Generic.Dictionary{`1,``0})")]
+		public void GenericTypeWithTypeParameters (string methodName, string docCommentId)
+		{
+			var type = GetTestType (typeof (N.GenericType<>.NestedGenericType<>));
+			var method = type.Methods.Single (m => m.Name == methodName);
+
+			AssertDocumentID ($"M:N.GenericType`1.NestedGenericType`1.{docCommentId}", method);
 		}
 
 		[Test]
@@ -276,6 +370,11 @@ namespace Mono.Cecil.Tests {
 		TypeDefinition GetTestType ()
 		{
 			return typeof (N.X).ToDefinition ();
+		}
+
+		TypeDefinition GetTestType (Type type)
+		{
+			return type.ToDefinition ();
 		}
 
 		static void AssertDocumentID (string docId, IMemberDefinition member)

--- a/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
+++ b/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
@@ -7,71 +7,71 @@ using Mono.Cecil.Rocks;
 namespace N
 {
 
-	/// <summary>
-	/// ID string generated is "T:N.X". 
-	/// </summary>
-	public class X : IX<KVP<string, int>>
-	{
-		/// <summary>
-		/// ID string generated is "M:N.X.#ctor".
-		/// </summary>
-		public X() { }
+    /// <summary>
+    /// ID string generated is "T:N.X". 
+    /// </summary>
+    public class X : IX<KVP<string, int>>
+    {
+        /// <summary>
+        /// ID string generated is "M:N.X.#ctor".
+        /// </summary>
+        public X() { }
 
 
-		/// <summary>
-		/// ID string generated is "M:N.X.#ctor(System.Int32)".
-		/// </summary>
-		/// <param name="i">Describe parameter.</param>
-		public X(int i) { }
+        /// <summary>
+        /// ID string generated is "M:N.X.#ctor(System.Int32)".
+        /// </summary>
+        /// <param name="i">Describe parameter.</param>
+        public X(int i) { }
 
 
-		/// <summary>
-		/// ID string generated is "F:N.X.q".
-		/// </summary>
-		public string q;
+        /// <summary>
+        /// ID string generated is "F:N.X.q".
+        /// </summary>
+        public string q;
 
 
-		/// <summary>
-		/// ID string generated is "F:N.X.PI".
-		/// </summary>
-		public const double PI = 3.14;
+        /// <summary>
+        /// ID string generated is "F:N.X.PI".
+        /// </summary>
+        public const double PI = 3.14;
 
 
-		/// <summary>
-		/// ID string generated is "M:N.X.f".
-		/// </summary>
-		public int f() { return 1; }
+        /// <summary>
+        /// ID string generated is "M:N.X.f".
+        /// </summary>
+        public int f() { return 1; }
 
 
-		/// <summary>
-		/// ID string generated is "M:N.X.bb(System.String,System.Int32@)".
-		/// </summary>
-		public int bb(string s, ref int y) { return 1; }
+        /// <summary>
+        /// ID string generated is "M:N.X.bb(System.String,System.Int32@)".
+        /// </summary>
+        public int bb(string s, ref int y) { return 1; }
 
 
-		/// <summary>
-		/// ID string generated is "M:N.X.gg(System.Int16[],System.Int32[0:,0:])". 
-		/// </summary>
-		public int gg(short[] array1, int[,] array) { return 0; }
+        /// <summary>
+        /// ID string generated is "M:N.X.gg(System.Int16[],System.Int32[0:,0:])". 
+        /// </summary>
+        public int gg(short[] array1, int[,] array) { return 0; }
 
 
-		/// <summary>
-		/// ID string generated is "M:N.X.op_Addition(N.X,N.X)". 
-		/// </summary>
-		public static X operator +(X x, X xx) { return x; }
+        /// <summary>
+        /// ID string generated is "M:N.X.op_Addition(N.X,N.X)". 
+        /// </summary>
+        public static X operator +(X x, X xx) { return x; }
 
 
-		/// <summary>
-		/// ID string generated is "P:N.X.prop".
-		/// </summary>
-		public int prop { get { return 1; } set { } }
+        /// <summary>
+        /// ID string generated is "P:N.X.prop".
+        /// </summary>
+        public int prop { get { return 1; } set { } }
 
 
-		/// <summary>
-		/// ID string generated is "E:N.X.d".
-		/// </summary>
+        /// <summary>
+        /// ID string generated is "E:N.X.d".
+        /// </summary>
 #pragma warning disable 67
-		public event D d;
+        public event D d;
 #pragma warning restore 67
 
 
@@ -81,32 +81,32 @@ namespace N
 		public int this[string s] { get { return 1; } }
 
 
-		/// <summary>
-		/// ID string generated is "T:N.X.Nested".
-		/// </summary>
-		public class Nested { }
+        /// <summary>
+        /// ID string generated is "T:N.X.Nested".
+        /// </summary>
+        public class Nested { }
 
 
-		/// <summary>
-		/// ID string generated is "T:N.X.D". 
-		/// </summary>
-		public delegate void D(int i);
+        /// <summary>
+        /// ID string generated is "T:N.X.D". 
+        /// </summary>
+        public delegate void D(int i);
 
 
-		/// <summary>
-		/// ID string generated is "M:N.X.op_Explicit(N.X)~System.Int32".
-		/// </summary>
-		public static explicit operator int(X x) { return 1; }
+        /// <summary>
+        /// ID string generated is "M:N.X.op_Explicit(N.X)~System.Int32".
+        /// </summary>
+        public static explicit operator int(X x) { return 1; }
 
 
 		public static void Linq (IEnumerable<string> enumerable, Func<string> selector) { }
 
 
-		/// <summary>
+        /// <summary>
 		/// ID string generated is "M:N.X.N#IX{N#KVP{System#String,System#Int32}}#IXA(N.KVP{System.String,System.Int32})"
-		/// </summary>
-		void IX<KVP<string, int>>.IXA (KVP<string, int> k) { }
-	}
+        /// </summary>
+        void IX<KVP<string, int>>.IXA (KVP<string, int> k) { }
+    }
 
 	public interface IX<K>
 	{
@@ -250,7 +250,7 @@ namespace Mono.Cecil.Tests {
 
 			AssertDocumentID ("M:N.X.bb(System.String,System.Int32@)", method);
 		}
-
+		
 		[Test]
 		public void MethodWithArrayParameters ()
 		{

--- a/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
+++ b/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
@@ -99,13 +99,15 @@ namespace N
         public static explicit operator int(X x) { return 1; }
 
 
-		public static void Linq (IEnumerable<string> enumerable, Func<string> selector) { }
+		public static void Linq (IEnumerable<string> enumerable, Func<string> selector)
+		{
+		}
 
 
-        /// <summary>
+		/// <summary>
 		/// ID string generated is "M:N.X.N#IX{N#KVP{System#String,System#Int32}}#IXA(N.KVP{System.String,System.Int32})"
-        /// </summary>
-        void IX<KVP<string, int>>.IXA (KVP<string, int> k) { }
+		/// </summary>
+		void IX<KVP<string, int>>.IXA (KVP<string, int> k) { }
     }
 
 	public interface IX<K>

--- a/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
+++ b/rocks/Test/Mono.Cecil.Tests/DocCommentIdTests.cs
@@ -106,7 +106,7 @@ namespace N
 		/// ID string generated is "M:N.X.N#IX{N#KVP{System#String,System#Int32}}#IXA(N.KVP{System.String,System.Int32})"
         /// </summary>
         void IX<KVP<string, int>>.IXA (KVP<string, int> k) { }
-	}
+    }
 
 	public interface IX<K>
 	{


### PR DESCRIPTION
Hi @jbevain, current when a method or generic method with a nested type argument and that is defined in a generic class, the DocCommentId can't generate the comment signature of the method correctly. I created a few test methods with some special arguments for generate test XML documentation and make the DocCommentId can generate the same comment signature.

I don't have the specifications document of XML documentation that I now just found a [basic introduction](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/processing-the-xml-file) in Microsoft Docs but the introduction hasn't described the rules of the generic method. Although the comment signature of the generic method looks like has been fixed and maybe it's not a standard implementation. If you have the specifications document could you share them with me?