### PR TITLE
Do not reset the stack size after a `break` instruction

### DIFF
--- a/Mono.Cecil.Cil/CodeWriter.cs
+++ b/Mono.Cecil.Cil/CodeWriter.cs
@@ -424,7 +424,6 @@ namespace Mono.Cecil.Cil {
 		{
 			switch (instruction.opcode.FlowControl) {
 			case FlowControl.Branch:
-			case FlowControl.Break:
 			case FlowControl.Throw:
 			case FlowControl.Return:
 				stack_size = 0;


### PR DESCRIPTION
This is just a minor correctness fix of something I noticed while reading the code.

`break` is not an unconditional jump instruction. It serves as a breakpoint for the debugger. This means it should not require the stack size of the next instruction to be zero (when there is no forward branch to it).

I don't think the C# compiler emits `break` instructions, so a unit test would have to use an assembly written in IL. I didn't think it's worth the trouble (as this change can only increase the `maxstack` value), but I can write one if you prefer.
