### PR TITLE
Addressing issue #781

### DIFF
--- a/Mono.Cecil.Cil/MethodBody.cs
+++ b/Mono.Cecil.Cil/MethodBody.cs
@@ -354,6 +354,8 @@ namespace Mono.Cecil.Cil {
 			if (scope.HasScopes) {
 				foreach (var subScope in scope.Scopes)
 					UpdateLocalScope (subScope, removedInstruction, existingInstruction, ref cache);
+				var dead = scope.Scopes.Where (s => s.Start.IsEndOfMethod).ToList ();
+				dead.ForEach (d => scope.Scopes.Remove (d));
 			}
 
 			if (!scope.End.IsResolved)

--- a/Mono.Cecil.Cil/MethodBody.cs
+++ b/Mono.Cecil.Cil/MethodBody.cs
@@ -312,7 +312,7 @@ namespace Mono.Cecil.Cil {
 			if (debug_info == null)
 				return;
 
-			// Local scopes store start/end pair of "instruction offsets". Instruction offset can be either resolved, in which case it 
+			// Local scopes store start/end pair of "instruction offsets". Instruction offset can be either resolved, in which case it
 			// has a reference to Instruction, or unresolved in which case it stores numerical offset (instruction offset in the body).
 			// Typically local scopes loaded from PE/PDB files will be resolved, but it's not a requirement.
 			// Each instruction has its own offset, which is populated on load, but never updated (this would be pretty expensive to do).
@@ -354,8 +354,6 @@ namespace Mono.Cecil.Cil {
 			if (scope.HasScopes) {
 				foreach (var subScope in scope.Scopes)
 					UpdateLocalScope (subScope, removedInstruction, existingInstruction, ref cache);
-				var dead = scope.Scopes.Where (s => s.Start.IsEndOfMethod).ToList ();
-				dead.ForEach (d => scope.Scopes.Remove (d));
 			}
 
 			if (!scope.End.IsResolved)
@@ -409,7 +407,7 @@ namespace Mono.Cecil.Cil {
 					// Allow for trailing null values in the case of
 					// instructions.Size < instructions.Capacity
 					if (item == null)
-						break;
+						return new InstructionOffset (items [i - 1]);
 
 					cache.Instruction = item;
 

--- a/Test/Mono.Cecil.Tests/ILProcessorTests.cs
+++ b/Test/Mono.Cecil.Tests/ILProcessorTests.cs
@@ -64,6 +64,45 @@ namespace Mono.Cecil.Tests {
 		}
 
 		[Test]
+		public void InsertBeforeIssue697bis ()
+		{
+			var parameters = new ReaderParameters { SymbolReaderProvider = new MdbReaderProvider () };
+			using (var module = GetResourceModule ("Issue697.dll", parameters)) {
+				var pathGetterDef = module.GetTypes ()
+					.SelectMany (t => t.Methods)
+					.First (m => m.Name.Equals ("get_Defer"));
+
+				var body = pathGetterDef.Body;
+				var worker = body.GetILProcessor ();
+				var initialBody = body.Instructions.ToList ();
+				Console.WriteLine (initialBody.Sum (i => i.GetSize ()));
+
+				var head = initialBody.First ();
+				var opcode = worker.Create (OpCodes.Ldc_I4_1);
+				worker.InsertBefore (head, opcode);
+
+				Assert.That (pathGetterDef.DebugInformation.Scope.Start.IsEndOfMethod, Is.False);
+				foreach (var subscope in pathGetterDef.DebugInformation.Scope.Scopes)
+					Assert.That (subscope.Start.IsEndOfMethod, Is.False);
+
+				// big test -- we can write w/o crashing
+				var unique = Guid.NewGuid ().ToString ();
+				var output = Path.GetTempFileName ();
+				var outputdll = output + ".dll";
+
+				var writer = new WriterParameters () {
+					SymbolWriterProvider = new MdbWriterProvider (),
+					WriteSymbols = true
+				};
+				using (var sink = File.Open (outputdll, FileMode.Create, FileAccess.ReadWrite)) {
+					module.Write (sink, writer);
+				}
+
+				Assert.Pass ();
+			}
+		}
+
+		[Test]
 		public void InsertAfter ()
 		{
 			var method = CreateTestMethod (OpCodes.Ldloc_0, OpCodes.Ldloc_2, OpCodes.Ldloc_3);


### PR DESCRIPTION
Fix the previous fix by not returning a default end-of-method value in this case, by making the end-of-method a proper stop.  This is possibly slightly bogus even so, but it's an rare edge case from not terribly well formed -- but executable -- input.