### PR TITLE
Allow custom CoreLibs to be specified & custom 'ParameterDefinition' to supply 'index' argument

### DIFF
--- a/Mono.Cecil.Cil/VariableDefinition.cs
+++ b/Mono.Cecil.Cil/VariableDefinition.cs
@@ -21,6 +21,12 @@ namespace Mono.Cecil.Cil {
 		{
 		}
 
+		public VariableDefinition (TypeReference variableType, int index)
+			: base (variableType)
+		{
+			this.index = index;
+		}
+
 		public override VariableDefinition Resolve ()
 		{
 			return this;

--- a/Mono.Cecil/FunctionPointerType.cs
+++ b/Mono.Cecil/FunctionPointerType.cs
@@ -107,5 +107,10 @@ namespace Mono.Cecil {
 		{
 			return this;
 		}
+
+		public override void SetElementType (TypeReference element)
+		{
+			// do nothing...
+		}
 	}
 }

--- a/Mono.Cecil/ParameterDefinition.cs
+++ b/Mono.Cecil/ParameterDefinition.cs
@@ -138,6 +138,14 @@ namespace Mono.Cecil {
 			this.token = new MetadataToken (TokenType.Param);
 		}
 
+		public ParameterDefinition (string name, ParameterAttributes attributes, TypeReference parameterType, int index)
+			: base (name, parameterType)
+		{
+			this.attributes = (ushort) attributes;
+			this.token = new MetadataToken (TokenType.Param);
+			this.index = index;
+		}
+
 		public override ParameterDefinition Resolve ()
 		{
 			return this;

--- a/Mono.Cecil/TypeReference.cs
+++ b/Mono.Cecil/TypeReference.cs
@@ -266,6 +266,11 @@ namespace Mono.Cecil {
 			return this;
 		}
 
+		public virtual void SetElementType (TypeReference element)
+		{
+			// do nothing...
+		}
+
 		protected override IMemberDefinition ResolveDefinition ()
 		{
 			return this.Resolve ();

--- a/Mono.Cecil/TypeSpecification.cs
+++ b/Mono.Cecil/TypeSpecification.cs
@@ -16,7 +16,7 @@ namespace Mono.Cecil {
 
 	public abstract class TypeSpecification : TypeReference {
 
-		readonly TypeReference element_type;
+		TypeReference element_type;
 
 		public TypeReference ElementType {
 			get { return element_type; }
@@ -63,6 +63,11 @@ namespace Mono.Cecil {
 		public override TypeReference GetElementType ()
 		{
 			return element_type.GetElementType ();
+		}
+
+		public override void SetElementType (TypeReference element)
+		{
+			element_type = element;
 		}
 	}
 }

--- a/Mono.Cecil/TypeSystem.cs
+++ b/Mono.Cecil/TypeSystem.cs
@@ -9,7 +9,7 @@
 //
 
 using System;
-
+using System.Collections.Generic;
 using Mono.Cecil.Metadata;
 
 namespace Mono.Cecil {
@@ -151,6 +151,8 @@ namespace Mono.Cecil {
 		TypeReference type_string;
 		TypeReference type_typedref;
 
+		internal static List<string> custom_corelibs;
+
 		TypeSystem (ModuleDefinition module)
 		{
 			this.module = module;
@@ -187,6 +189,19 @@ namespace Mono.Cecil {
 				type.KnownValueType ();
 				return typeRef = type;
 			}
+		}
+
+		public static void AddCustomCoreLib(string libraryName)
+		{
+			if (custom_corelibs == null)
+				custom_corelibs = new List<string>();
+			custom_corelibs.Add(libraryName);
+		}
+
+		public static void RemoveCustomCoreLib(string libraryName)
+		{
+			if (custom_corelibs != null)
+				custom_corelibs.Remove(libraryName);
 		}
 
 		[Obsolete ("Use CoreLibrary")]
@@ -322,10 +337,24 @@ namespace Mono.Cecil {
 		static bool IsCoreLibrary (AssemblyNameReference reference)
 		{
 			var name = reference.Name;
-			return name == mscorlib
+
+			// well known core libraries
+			if (name == mscorlib
 				|| name == system_runtime
 				|| name == system_private_corelib
-				|| name == netstandard;
+				|| name == netstandard) {
+				return true;
+			}
+
+			// custom core libraries
+			if (TypeSystem.custom_corelibs != null) {
+				foreach (string libName in TypeSystem.custom_corelibs) {
+					if (libName == name)
+						return true;
+				}
+			}
+
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
I've been working on a project called IL2X again (a IL to C89, etc compiler): https://github.com/reignstudios/IL2X/tree/remake

First Mono.Cecil is missing a feature that allows me to specify non-standard CoreLib names. In this case "IL2X.CoreLib".
This is needed when compiling for non-standard .NET runtimes.

Second when IL2X resolves Generics for parameters it needs to create a new resolved 'ParameterDefinition' that uses the same index from the original unresolved param its based on (in short allow custom index arg in the constructor).

Third, same as ParameterDefinition but also for VariableDefinition.