### PR TITLE
Add public API to shallow copy instruction instances

### DIFF
--- a/Mono.Cecil.Cil/Instruction.cs
+++ b/Mono.Cecil.Cil/Instruction.cs
@@ -59,6 +59,11 @@ namespace Mono.Cecil.Cil {
 			this.operand = operand;
 		}
 
+		public Instruction GetPrototype ()
+		{
+			return new Instruction (opcode, operand);
+		}
+
 		public int GetSize ()
 		{
 			int size = opcode.Size;


### PR DESCRIPTION
It is useful for example for easier propagation of instructions into
multiple method bodies.