### PR TITLE
Add `MethodImplAttributes.AggressiveOptimization`

### DIFF
--- a/Mono.Cecil/MethodDefinition.cs
+++ b/Mono.Cecil/MethodDefinition.cs
@@ -440,6 +440,11 @@ namespace Mono.Cecil {
 			set { impl_attributes = impl_attributes.SetAttributes ((ushort) MethodImplAttributes.AggressiveInlining, value); }
 		}
 
+		public bool AggressiveOptimization {
+			get { return impl_attributes.GetAttributes ((ushort) MethodImplAttributes.AggressiveOptimization); }
+			set { impl_attributes = impl_attributes.SetAttributes ((ushort) MethodImplAttributes.AggressiveOptimization, value); }
+		}
+
 		#endregion
 
 		#region MethodSemanticsAttributes

--- a/Mono.Cecil/MethodImplAttributes.cs
+++ b/Mono.Cecil/MethodImplAttributes.cs
@@ -14,23 +14,24 @@ namespace Mono.Cecil {
 
 	[Flags]
 	public enum MethodImplAttributes : ushort {
-		CodeTypeMask		= 0x0003,
-		IL					= 0x0000,	// Method impl is CIL
-		Native				= 0x0001,	// Method impl is native
-		OPTIL				= 0x0002,	// Reserved: shall be zero in conforming implementations
-		Runtime				= 0x0003,	// Method impl is provided by the runtime
+		CodeTypeMask			= 0x0003,
+		IL						= 0x0000,	// Method impl is CIL
+		Native					= 0x0001,	// Method impl is native
+		OPTIL					= 0x0002,	// Reserved: shall be zero in conforming implementations
+		Runtime					= 0x0003,	// Method impl is provided by the runtime
 
-		ManagedMask			= 0x0004,	// Flags specifying whether the code is managed or unmanaged
-		Unmanaged			= 0x0004,	// Method impl is unmanaged, otherwise managed
-		Managed				= 0x0000,	// Method impl is managed
+		ManagedMask				= 0x0004,	// Flags specifying whether the code is managed or unmanaged
+		Unmanaged				= 0x0004,	// Method impl is unmanaged, otherwise managed
+		Managed					= 0x0000,	// Method impl is managed
 
-		// Implementation info and interop
-		ForwardRef			= 0x0010,	// Indicates method is defined; used primarily in merge scenarios
-		PreserveSig			= 0x0080,	// Reserved: conforming implementations may ignore
-		InternalCall		= 0x1000,	// Reserved: shall be zero in conforming implementations
-		Synchronized		= 0x0020,	// Method is single threaded through the body
-		NoOptimization		= 0x0040,	// Method is not optimized by the JIT.
-		NoInlining			= 0x0008,	// Method may not be inlined
-		AggressiveInlining  = 0x0100,   // Method should be inlined, if possible.
+		ForwardRef				= 0x0010,	// The method is declared, but its implementation is provided elsewhere.
+		PreserveSig				= 0x0080,	// The method signature is exported exactly as declared.
+		InternalCall			= 0x1000,	// The call is internal, that is, it calls a method that's implemented within the CLR.
+		Synchronized			= 0x0020,	// The method can be executed by only one thread at a time.
+		 									// Static methods lock on the type, whereas instance methods lock on the instance.
+		NoOptimization			= 0x0040,	// The method is not optimized by the just-in-time (JIT) compiler or by native codegen.
+		NoInlining				= 0x0008,	// The method cannot be inlined.
+		AggressiveInlining		= 0x0100,	// The method should be inlined if possible.
+		AggressiveOptimization	= 0x0200,	// The method contains code that should always be optimized by the JIT compiler.
 	}
 }


### PR DESCRIPTION
In [.NET Core 3.0 and later](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.methodimploptions?view=netcore-3.0), `MethodImplOptions` got a new flag value, `AggressiveOptimization` (512).

This adds that same flag to `MethodImplAttributes` (and a corresponding property to `MethodDefinition`). It also updates the comments for the flags to match the `MethodImplOptions` documentation better.