### PR TITLE
Develop/issue 863

### DIFF
--- a/Mono.Cecil/BaseAssemblyResolver.cs
+++ b/Mono.Cecil/BaseAssemblyResolver.cs
@@ -147,7 +147,7 @@ namespace Mono.Cecil {
 			throw new AssemblyResolutionException (name);
 		}
 
-		protected AssemblyDefinition LastChanceResolution (AssemblyDefinition assembly, AssemblyNameReference name, ReaderParameters parameters)
+		protected virtual AssemblyDefinition LastChanceResolution (AssemblyDefinition assembly, AssemblyNameReference name, ReaderParameters parameters)
 		{
 			if (ResolveFailure != null) {
 				assembly = ResolveFailure (this, name);


### PR DESCRIPTION
This is a change towards addressing the platform dependent behaviour of the Cecil binaries when resolving system assemblies.

This change extracts the net core and framework system assembly search strategies into `protected` methods that will be available in all builds -- avoiding the need to reimplement both in a platform neutral subclass; and provides a hook for examining the result before or after any resolution handler invocation, and making any other adjustments before an exception is thrown.

There are no changes to the existing platform dependent behaviour at this point -- the NET_CORE build doesn't look in the GAC, and the !NET_CORE one doesn't look in the dotnet shared locations, for example.