### PR TITLE
InvariantCulture for operand to string conversion in Instruction.ToString()

### DIFF
--- a/Mono.Cecil.Cil/Instruction.cs
+++ b/Mono.Cecil.Cil/Instruction.cs
@@ -9,6 +9,7 @@
 //
 
 using System;
+using System.Globalization;
 using System.Text;
 
 namespace Mono.Cecil.Cil {
@@ -122,11 +123,11 @@ namespace Mono.Cecil.Cil {
 				break;
 			case OperandType.InlineString:
 				instruction.Append ('\"');
-				instruction.Append (operand);
+				instruction.Append (Convert.ToString(operand, CultureInfo.InvariantCulture));
 				instruction.Append ('\"');
 				break;
 			default:
-				instruction.Append (operand);
+				instruction.Append (Convert.ToString(operand, CultureInfo.InvariantCulture));
 				break;
 			}
 

--- a/Mono.Cecil.Cil/Instruction.cs
+++ b/Mono.Cecil.Cil/Instruction.cs
@@ -123,7 +123,7 @@ namespace Mono.Cecil.Cil {
 				break;
 			case OperandType.InlineString:
 				instruction.Append ('\"');
-				instruction.Append (Convert.ToString(operand, CultureInfo.InvariantCulture));
+				instruction.Append (operand);
 				instruction.Append ('\"');
 				break;
 			default:


### PR DESCRIPTION
Instruction.ToString() uses the culture of the current thread, which can be problematic for converting doubles and floats to a string.