### PR TITLE
Fix a StackOverflowException reading windows runtime assemblies.

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -2508,7 +2508,7 @@ namespace Mono.Cecil {
 
 			if (module.IsWindowsMetadata ())
 				foreach (var custom_attribute in custom_attributes)
-					WindowsRuntimeProjections.Project (owner, custom_attribute);
+					WindowsRuntimeProjections.Project (owner, custom_attributes, custom_attribute);
 
 			return custom_attributes;
 		}

--- a/Mono.Cecil/WindowsRuntimeProjections.cs
+++ b/Mono.Cecil/WindowsRuntimeProjections.cs
@@ -241,7 +241,7 @@ namespace Mono.Cecil {
 					treatment = TypeDefinitionTreatment.PrefixWindowsRuntimeName;
 
 				if (treatment == TypeDefinitionTreatment.PrefixWindowsRuntimeName || treatment == TypeDefinitionTreatment.NormalType)
-					if (!type.IsInterface && HasAttribute (type, "Windows.UI.Xaml", "TreatAsAbstractComposableClassAttribute"))
+					if (!type.IsInterface && HasAttribute (type.CustomAttributes, "Windows.UI.Xaml", "TreatAsAbstractComposableClassAttribute"))
 						treatment |= TypeDefinitionTreatment.Abstract;
 			}
 			else if (metadata_kind == MetadataKind.ManagedWindowsMetadata && IsClrImplementationType (type))
@@ -860,7 +860,7 @@ namespace Mono.Cecil {
 			throw new Exception ();
 		}
 
-		public static void Project (ICustomAttributeProvider owner, CustomAttribute attribute)
+		public static void Project (ICustomAttributeProvider owner, Collection<CustomAttribute> owner_attributes, CustomAttribute attribute)
 		{
 			if (!IsWindowsAttributeUsageAttribute (owner, attribute))
 				return;
@@ -876,7 +876,7 @@ namespace Mono.Cecil {
 			}
 
 			if (treatment == CustomAttributeValueTreatment.None) {
-				var multiple = HasAttribute (type, "Windows.Foundation.Metadata", "AllowMultipleAttribute");
+				var multiple = HasAttribute (owner_attributes, "Windows.Foundation.Metadata", "AllowMultipleAttribute");
 				treatment = multiple ? CustomAttributeValueTreatment.AllowMultiple : CustomAttributeValueTreatment.AllowSingle;
 			}
 
@@ -905,9 +905,9 @@ namespace Mono.Cecil {
 			return declaring_type.Name == "AttributeUsageAttribute" && declaring_type.Namespace == /*"Windows.Foundation.Metadata"*/"System";
 		}
 
-		static bool HasAttribute (TypeDefinition type, string @namespace, string name)
+		static bool HasAttribute (Collection<CustomAttribute> attributes, string @namespace, string name)
 		{
-			foreach (var attribute in type.CustomAttributes) {
+			foreach (var attribute in attributes) {
 				var attribute_type = attribute.AttributeType;
 				if (attribute_type.Name == name && attribute_type.Namespace == @namespace)
 					return true;

--- a/Test/Mono.Cecil.Tests/ImageReadTests.cs
+++ b/Test/Mono.Cecil.Tests/ImageReadTests.cs
@@ -182,7 +182,7 @@ namespace Mono.Cecil.Tests {
 		[Test]
 		public void WindowsRuntimeComponentAssembly ()
 		{
-			var resolver = WindowsRuntimeAssemblyResolver.CreateInstance ();
+			var resolver = WindowsRuntimeAssemblyResolver.CreateInstance (applyWindowsRuntimeProjections: false);
 			if (resolver == null)
 				return;
 


### PR DESCRIPTION
During `AssemblyReader.ReadCustomAttributes` there is a call to `WindowsRuntimeProjections.Project`

```
if (module.IsWindowsMetadata ())
	foreach (var custom_attribute in custom_attributes)
		WindowsRuntimeProjections.Project (owner, custom_attributes, custom_attribute);
```

`WindowsRuntimeProjections.Project` would call `WindowsRuntimeProjections.HasAttribute`, which would then call `type.CustomAttributes`, which would end up back in `AssemblyReader.ReadCustomAttributes`. This would lead to a StackOverflowException.

This wasn't an issue previously.  My PR https://github.com/jbevain/cecil/pull/843 caused this sequence of calls to start resulting in a StackOverflowException.

Prior to my PR, there was a call to `metadata.RemoveCustomAttributeRange (owner);` before the call to `WindowsRuntimeProjections.Project`.  This meant that when `WindowsRuntimeProjections.HasAttribute` would call `type.CustomAttributes`, we'd still end up in `AssemblyReader.ReadCustomAttributes`, however, no attributes would be found because the following if would be true and lead to returning an empty collection.
```
if (!metadata.TryGetCustomAttributeRanges (owner, out ranges))
    return new Collection<CustomAttribute> ();
```

The old behavior was probably the wrong.  Although I'm not certain what the tangible impact was.

The fix was pretty easy.  `AssemblyReader.ReadCustomAttributes` will now pass in the custom attributes to `WindowsRuntimeProjections.Project` avoiding the need to call `type.CustomAttributes`