### PR TITLE
Make Cecil guess a type of constant when it cannot resolve a reference assembly

### DIFF
--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1878,7 +1878,19 @@ namespace Mono.Cecil {
 		void AddConstant (IConstantProvider owner, TypeReference type)
 		{
 			var constant = owner.Constant;
-			var etype = GetConstantType (type, constant);
+			ElementType etype;
+			try {
+				etype = GetConstantType (type, constant);
+			}
+			catch {
+				if (int.TryParse (constant.ToString (), out int intConstant)) {
+					constant = intConstant;
+					etype = ElementType.I4;
+				} else {
+					constant = constant.ToString ();
+					etype = ElementType.String;
+				}
+			}
 
 			constant_table.AddRow (new ConstantRow (
 				etype,


### PR DESCRIPTION
Make Cecil guess a type of constant when it cannot resolve a reference assembly.
Scenario:
We are writing a program that reads an assembly, edit the loaded assembly, and then writes it back to file.
When the program is working with an assembly A.dll that references to B.dll but B.dll is missing when the program is working.
Sometimes, the program cannot write the assembly back and it happens when A.dll uses an enum defined in B.dll (which is not present).

This PR make Cecil does the best effort to guess the type of enum and not fails in the specified scenario.