### PR TITLE
Treat instance and static methods as different methods during resolution

### DIFF
--- a/Mono.Cecil/MetadataResolver.cs
+++ b/Mono.Cecil/MetadataResolver.cs
@@ -264,6 +264,9 @@ namespace Mono.Cecil {
 				if (!AreSame (method.ReturnType, reference.ReturnType))
 					continue;
 
+				if (method.HasThis != reference.HasThis)
+					continue;
+
 				if (method.IsVarArg () != reference.IsVarArg ())
 					continue;
 

--- a/Test/Mono.Cecil.Tests/MethodTests.cs
+++ b/Test/Mono.Cecil.Tests/MethodTests.cs
@@ -221,5 +221,20 @@ namespace Mono.Cecil.Tests {
 			Assert.IsNotNull (method);
 			Assert.AreEqual (method, method.MethodReturnType.Parameter.Method);
 		}
+
+		[Test]
+		public void InstanceAndStaticMethodComparison ()
+		{
+			TestIL ("others.il", module => {
+				var others = module.GetType ("Others");
+				var instance_method = others.Methods.Single (m => m.Name == "SameMethodNameInstanceStatic" && m.HasThis);
+				var static_method_reference = new MethodReference ("SameMethodNameInstanceStatic", instance_method.ReturnType, others)
+					{
+						HasThis = false
+					};
+
+				Assert.AreNotEqual(instance_method, static_method_reference.Resolve ());
+			});
+		}
 	}
 }

--- a/Test/Resources/il/others.il
+++ b/Test/Resources/il/others.il
@@ -78,4 +78,14 @@
 		.other instance void Others::dang_Handler (class [mscorlib]System.EventHandler)
 		.other instance void Others::fang_Handler (class [mscorlib]System.EventHandler)
 	}
+	
+	.method public instance void  SameMethodNameInstanceStatic() cil managed
+	{
+		ret
+	}
+
+	.method public static void  SameMethodNameInstanceStatic() cil managed
+	{
+		ret
+	} // end of static method MethodNameTests::MethodName
 }


### PR DESCRIPTION
When all other comparisons (return type, parameters, etc.) are the same, treat instance and static methods with the same name as different methods.

This corrects a problem we noticed in IL2CPP in Unity.