### PR TITLE
Fix that method resolution would consider all function-pointers to be the same

### DIFF
--- a/Mono.Cecil/MetadataResolver.cs
+++ b/Mono.Cecil/MetadataResolver.cs
@@ -334,6 +334,35 @@ namespace Mono.Cecil {
 			if (a.IsArray)
 				return AreSame ((ArrayType) a, (ArrayType) b);
 
+			if (a.IsFunctionPointer)
+				return AreSame ((FunctionPointerType) a, (FunctionPointerType) b);
+
+			return true;
+		}
+
+		static bool AreSame (FunctionPointerType a, FunctionPointerType b)
+		{
+			if (a.HasThis != b.HasThis)
+				return false;
+			
+			if (a.CallingConvention != b.CallingConvention)
+				return false;
+
+			if (!AreSame (a.ReturnType, b.ReturnType))
+				return false;
+
+			if (a.ContainsGenericParameter != b.ContainsGenericParameter)
+				return false;
+
+			if (a.HasParameters != b.HasParameters)
+				return false;
+
+			if (!a.HasParameters)
+				return true;
+
+			if (!AreSame (a.Parameters, b.Parameters))
+				return false;
+			
 			return true;
 		}
 

--- a/Test/Resources/il/others.il
+++ b/Test/Resources/il/others.il
@@ -78,7 +78,22 @@
 		.other instance void Others::dang_Handler (class [mscorlib]System.EventHandler)
 		.other instance void Others::fang_Handler (class [mscorlib]System.EventHandler)
 	}
-	
+
+	.method public static void OverloadedWithFpArg(method int32 *(int32) X) cil managed
+	{
+	    ret
+	}
+
+	.method public static void OverloadedWithFpArg(method int32 *(int64) X) cil managed
+	{
+	    ret
+	}
+
+	.method public static void OverloadedWithFpArg(method unmanaged cdecl int32 *(int32) X) cil managed
+	{
+	    ret
+	}
+
 	.method public instance void  SameMethodNameInstanceStatic() cil managed
 	{
 		ret


### PR DESCRIPTION
`AreSame` for type-specifications doesn't handle function pointer types, and as a side-effect will consider all function pointer types the same. 

This fixes the problem that we noticed in the Burst compiler in Unity.