### PR TITLE
Fix RVA field alignment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
     - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v1
     - name: Build
@@ -20,7 +20,7 @@ jobs:
     - name: Test
       run: dotnet test --no-build -c Debug Mono.Cecil.sln
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - name: Build

--- a/Mono.Cecil.Cil/CodeWriter.cs
+++ b/Mono.Cecil.Cil/CodeWriter.cs
@@ -32,7 +32,7 @@ namespace Mono.Cecil.Cil {
 		public CodeWriter (MetadataBuilder metadata)
 			: base (0)
 		{
-			this.code_base = metadata.text_map.GetNextRVA (TextSegment.CLIHeader);
+			this.code_base = metadata.text_map.GetRVA (TextSegment.Code);
 			this.metadata = metadata;
 			this.standalone_signatures = new Dictionary<uint, MetadataToken> ();
 			this.tiny_method_bodies = new Dictionary<ByteBuffer, RVA> (new ByteBufferEqualityComparer ());

--- a/Mono.Cecil.PE/ImageWriter.cs
+++ b/Mono.Cecil.PE/ImageWriter.cs
@@ -696,7 +696,7 @@ namespace Mono.Cecil.PE {
 		{
 			var map = text_map;
 
-			map.AddMap (TextSegment.Code, metadata.code.length);
+			map.AddMap (TextSegment.Code, metadata.code.length, !pe64 ? 4 : 16);
 			map.AddMap (TextSegment.Resources, metadata.resources.length, 8);
 			map.AddMap (TextSegment.Data, metadata.data.length, metadata.data.BufferAlign);
 			if (metadata.data.length > 0)

--- a/Mono.Cecil.PE/ImageWriter.cs
+++ b/Mono.Cecil.PE/ImageWriter.cs
@@ -696,7 +696,7 @@ namespace Mono.Cecil.PE {
 		{
 			var map = text_map;
 
-			map.AddMap (TextSegment.Code, metadata.code.length, !pe64 ? 4 : 16);
+			map.AddMap (TextSegment.Code, metadata.code.length);
 			map.AddMap (TextSegment.Resources, metadata.resources.length, 8);
 			map.AddMap (TextSegment.Data, metadata.data.length, metadata.data.BufferAlign);
 			if (metadata.data.length > 0)

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -987,6 +987,11 @@ namespace Mono.Cecil {
 			var map = new TextMap ();
 			map.AddMap (TextSegment.ImportAddressTable, module.Architecture == TargetArchitecture.I386 ? 8 : 0);
 			map.AddMap (TextSegment.CLIHeader, 0x48, 8);
+			var pe64 = module.Architecture == TargetArchitecture.AMD64 || module.Architecture == TargetArchitecture.IA64 || module.Architecture == TargetArchitecture.ARM64;
+			// Alignment of the code segment must be set before the code is written
+			// These alignment values are probably not necessary, but are being left in
+			// for now in case something requires them.
+			map.AddMap (TextSegment.Code, 0, !pe64 ? 4 : 16);
 			return map;
 		}
 

--- a/Test/Mono.Cecil.Tests/FieldTests.cs
+++ b/Test/Mono.Cecil.Tests/FieldTests.cs
@@ -160,7 +160,7 @@ namespace Mono.Cecil.Tests {
 					var priv_impl = GetPrivateImplementationType (module);
 					Assert.IsNotNull (priv_impl);
 
-					Assert.AreEqual (6, priv_impl.Fields.Count);
+					Assert.AreEqual (8, priv_impl.Fields.Count);
 
 					foreach (var field in priv_impl.Fields)
 					{
@@ -170,7 +170,8 @@ namespace Mono.Cecil.Tests {
 						Assert.IsNotNull (field.InitialValue);
 
 						int rvaAlignment = AlignmentOfInteger (field.RVA);
-						int desiredAlignment = Math.Min(8, AlignmentOfInteger (field.InitialValue.Length));
+						var fieldType = field.FieldType.Resolve ();
+						int desiredAlignment = fieldType.PackingSize;
 						Assert.GreaterOrEqual (rvaAlignment, desiredAlignment);
 					}
 				}

--- a/Test/Resources/il/FieldRVAAlignment.il
+++ b/Test/Resources/il/FieldRVAAlignment.il
@@ -46,12 +46,22 @@
     .size 6
   } // end of class '__StaticArrayInitTypeSize=6'
 
+  .class explicit ansi sealed nested private '__StaticArrayInitTypeSize=4Align=32'
+        extends [mscorlib]System.ValueType
+  {
+    .pack 32
+    .size 4
+  }
+
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=3' '$$method0x6000001-1' at I_000020F0
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=20' '$$method0x6000001-2' at I_000020F8
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=5' '$$method0x6000001-3' at I_00002108
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=20' '$$method0x6000001-4' at I_00002110
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=6' '$$method0x6000001-5' at I_00002120
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=16' '$$method0x6000001-6' at I_00002130
+  .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=3' 'separator' at I_00002140
+  .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=4Align=32' '32_align' at I_00002150
+
 } // end of class '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'
 
 
@@ -69,3 +79,7 @@
                  08 00 0C 00 0D 00) 
 .data cil I_00002130 = bytearray (
                  01 00 00 00 02 00 00 00 03 00 00 00 05 00 00 00) 
+.data cil I_00002140 = bytearray (
+                 01 02 03)
+.data cil I_00002150 = bytearray (
+                 01 02 03 04)


### PR DESCRIPTION
Upstreaming the change from https://github.com/dotnet/cecil/pull/55.

Fixes https://github.com/dotnet/runtime/issues/79477, specifically, the problem described in https://github.com/dotnet/runtime/issues/79477#issuecomment-1354917614.

This ensures that section starts are aligned by adjusting the previous `Range`'s length to ensure the computed start of a new `Range` meets the alignment requirements. It was done this way rather than just computing an aligned start for the new `Range`, because the `TextMap` assumes that the `Range`s are contiguous - see for example `GetNextRVA`.