### PR TITLE
Use v1.0.3 of the .NET FW reference assemblies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.3" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />


### PR DESCRIPTION
With MSBuild 7.0.201 and later, building the Mono.Cecil projects used by Unity's IL2CPP causes warning NU1605 to occur, indicating that there is a package version mismatch between the .NET Framework reference assemblies package used. To avoid this, bump the version used by Mono.Cecil and similar project to be the latest, version 1.0.3.

Note that MSBuild version 7.0.100 and earlier did not cause this warning to occur.