### PR TITLE
Add public API for instruction clonning

### DIFF
--- a/Mono.Cecil.Cil/Instruction.cs
+++ b/Mono.Cecil.Cil/Instruction.cs
@@ -60,6 +60,11 @@ namespace Mono.Cecil.Cil {
 			this.operand = operand;
 		}
 
+		public Instruction GetPrototype ()
+		{
+			return new Instruction (opcode, operand);
+		}
+
 		public int GetSize ()
 		{
 			int size = opcode.Size;


### PR DESCRIPTION
This change was originally made to dotnet/cecil by @marek-safar https://github.com/dotnet/cecil/commit/0780d4e15ef42b56a4e40dafac0d5486f09ce005

We are in the process of updating UnityLinker to a newer revision of ILLink and we compile with Unity's fork of cecil instead of the dotnet cecil.  Landing this change upstream will get everyone in sync.