### PR TITLE
Fix privatescope method resolution bug

### DIFF
--- a/Test/Resources/il/privatescope.il
+++ b/Test/Resources/il/privatescope.il
@@ -1,0 +1,77 @@
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89)
+  .ver 2:0:0:0
+}
+
+.assembly PrivateScope {}
+
+.module PrivateScope.dll
+
+.class private auto ansi Foo {
+
+  .method public specialname rtspecialname instance void .ctor () cil managed
+  {
+    ldarg.0
+    call instance void [mscorlib]System.Object::.ctor ()
+    ret
+  }
+
+  .method public instance void  CallSameNameMethods() cil managed
+  {
+    ldarg.0
+    call      instance void Foo::'SameName'()
+    ldarg.0
+    call      instance void Foo::'SameName$PST0600A3BA'()
+    ldarg.0
+    call      instance void Foo::'SameName$PST0600A3BC'()
+    ret
+  }
+
+ .method public hidebysig
+    instance void 'SameName' () cil managed
+  {
+    ret
+  }
+
+  .method privatescope
+    instance void 'SameName$PST0600A3BA' () cil managed
+  {
+    ret
+  }
+
+  .method privatescope
+    instance void 'SameName$PST0600A3BC' () cil managed
+  {
+    ret
+  }
+  
+  .method public instance void  CallSameNameMethodsGeneric() cil managed
+  {
+    ldarg.0
+    call      instance void Foo::'SameNameGeneric'<int32>()
+    ldarg.0
+    call      instance void Foo::'SameNameGeneric$PST0600A3BD'<int32>()
+    ldarg.0
+    call      instance void Foo::'SameNameGeneric$PST0600A3BE'<int32>()
+    ret
+  }
+
+ .method public hidebysig
+    instance void 'SameNameGeneric'<T> () cil managed
+  {
+    ret
+  }
+
+  .method privatescope
+    instance void 'SameNameGeneric$PST0600A3BD'<T> () cil managed
+  {
+    ret
+  }
+
+  .method privatescope
+    instance void 'SameNameGeneric$PST0600A3BE'<T> () cil managed
+  {
+    ret
+  }
+}


### PR DESCRIPTION
When resolving a `GenericInstanceMethod` for a `privatescope` method that has the same signature as other methods, `MetadataResolver.GetMethod` would incorrectly return the first method with the same name.

The fix for this seems to be an optimization opportunity as well.  Although I have to admit it feels a little too easy.  Please make sure I'm not overlooking some reason why this fix is not safe.

I added 2 variations of tests.

`PrivateScope` - These tests were fine and passed as is.  This is because the instruction operands are MethodDefinitions and therefore didn't need to be resolved by `MetadataResolver`

`PrivateScopeGeneric` - This test triggered the bug.