### PR TITLE
Add modreq and modopt to imported FieldRefs

### DIFF
--- a/Mono.Cecil/Import.cs
+++ b/Mono.Cecil/Import.cs
@@ -346,10 +346,17 @@ namespace Mono.Cecil {
 
 			context.Push (declaring_type);
 			try {
+				var field_type = ImportType (field.FieldType, context);
+
+				foreach (var t in field.GetRequiredCustomModifiers ())
+					field_type = new RequiredModifierType (ImportType (t, context), field_type);
+				foreach (var t in field.GetOptionalCustomModifiers ())
+					field_type = new OptionalModifierType (ImportType (t, context), field_type);
+
 				return new FieldReference {
 					Name = field.Name,
 					DeclaringType = declaring_type,
-					FieldType = ImportType (field.FieldType, context),
+					FieldType = field_type,
 				};
 			} finally {
 				context.Pop ();


### PR DESCRIPTION
When importing a FieldReference using the DefaultReflectionImporter, the volatile modifier was lost. This resulted in a
System.MissingFieldException at runtime if one wanted to access such field via Cecil emitted IL. The bare type was used for the field, excluding the modreq IsVolatile modifier.

This commit wraps the field's type into RequiredModifierType and OptionalModifierType objects, this way the writer emits correct IL for the volatile field reference.

I hope my commit message is clear in what the problem was, and what my solution is. It definitely needs a test, which I am unsure of where to put. I only found one method calling `ModuleDefinition.ImportReference(FieldInfo)` and that deals with generics.
I've tested my code with a `static volatile bool[]` field in a C# library. I don't know any other modreq at the moment, and I think modopt is only used for C++. I am also not sure how multiple modreq and modopt should be handled (or where do I even encounter them), in what order.

I am new to Cecil, so my code might be janky a bit, but I'm open to suggestions. I didn't want to just open an issue and wait for someone to fix it, I've tried, and it works for me, treat it as an MVC.