### PR TITLE
fixbug: fix exception about failed to resolve TupleElementNamesAttribute:.ctor sometime

### DIFF
--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1769,6 +1769,10 @@ namespace Mono.Cecil {
 				sequence,
 				GetStringIndex (parameter.Name)));
 
+			// fixbug: update custom attributes and others before update token
+			_ = parameter.CustomAttributes;
+			var hasMarshalInfo = parameter.HasMarshalInfo;
+			
 			parameter.token = new MetadataToken (TokenType.Param, param_rid++);
 
 			if (parameter.HasCustomAttributes)
@@ -1777,7 +1781,7 @@ namespace Mono.Cecil {
 			if (parameter.HasConstant)
 				AddConstant (parameter, parameter.ParameterType);
 
-			if (parameter.HasMarshalInfo)
+			if (hasMarshalInfo)
 				AddMarshalInfo (parameter);
 		}
 


### PR DESCRIPTION
fix #937 
fixbug: fix exception about failed to resolve TupleElementNamesAttribute:.ctor sometime

The key "parameter.token" is updated, but the dictionary "CustomAttributes" not, thus get CustomAttribute by parameter.token as key will return wrong value. When it LookupToken will throw exception for unmatched module of wrong CustomAttribute.

![image](https://github.com/jbevain/cecil/assets/9778097/048e9501-c9c8-4be4-9446-fc7fa7d38789)
![image](https://github.com/jbevain/cecil/assets/9778097/b58f1bfa-0786-47ef-8745-eab84d291f41)

