### PR TITLE
Address issue 938 by choosing a FIPS compliant implementation

### DIFF
--- a/Mono.Security.Cryptography/CryptoService.cs
+++ b/Mono.Security.Cryptography/CryptoService.cs
@@ -93,7 +93,7 @@ namespace Mono.Cecil {
 				+ (strong_name_directory.VirtualAddress - text.VirtualAddress));
 			var strong_name_length = (int) strong_name_directory.Size;
 
-			var sha1 = new SHA1Managed ();
+			var sha1 = new SHA1CryptoServiceProvider ();
 			var buffer = new byte [buffer_size];
 			using (var crypto_stream = new CryptoStream (Stream.Null, sha1, CryptoStreamMode.Write)) {
 				stream.Seek (0, SeekOrigin.Begin);
@@ -131,7 +131,7 @@ namespace Mono.Cecil {
 		{
 			const int buffer_size = 8192;
 
-			var sha1 = new SHA1Managed ();
+			var sha1 = new SHA1CryptoServiceProvider ();
 			var buffer = new byte [buffer_size];
 
 			using (var crypto_stream = new CryptoStream (Stream.Null, sha1, CryptoStreamMode.Write))
@@ -142,7 +142,7 @@ namespace Mono.Cecil {
 
 		public static byte [] ComputeHash (params ByteBuffer [] buffers)
 		{
-			var sha1 = new SHA1Managed ();
+			var sha1 = new SHA1CryptoServiceProvider ();
 
 			using (var crypto_stream = new CryptoStream (Stream.Null, sha1, CryptoStreamMode.Write)) {
 				for (int i = 0; i < buffers.Length; i++) {

--- a/Test/Mono.Cecil.Tests.csproj
+++ b/Test/Mono.Cecil.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="..\Mono.Cecil.Tests.props" />
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net40</TargetFrameworks>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">

--- a/rocks/Test/Mono.Cecil.Rocks.Tests.csproj
+++ b/rocks/Test/Mono.Cecil.Rocks.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="..\..\Mono.Cecil.Tests.props" />
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net40</TargetFrameworks>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Mono.Cecil.csproj">

--- a/symbols/mdb/Test/Mono.Cecil.Mdb.Tests.csproj
+++ b/symbols/mdb/Test/Mono.Cecil.Mdb.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="..\..\..\Mono.Cecil.Tests.props" />
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net40</TargetFrameworks>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mono.Cecil.csproj">

--- a/symbols/pdb/Test/Mono.Cecil.Pdb.Tests.csproj
+++ b/symbols/pdb/Test/Mono.Cecil.Pdb.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="..\..\..\Mono.Cecil.Tests.props" />
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net40</TargetFrameworks>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mono.Cecil.csproj">


### PR DESCRIPTION
Replacing use of `SHA1Managed` with the compliant `SHA1CryptoServiceProvider` implementation.

Also, as a convenience, adding RollForward Major to the test projects so they will run on a machine with only net60 and up installed.