### PR TITLE
Add RISCV64 TargetArchitecture

### DIFF
--- a/Mono.Cecil.PE/ImageWriter.cs
+++ b/Mono.Cecil.PE/ImageWriter.cs
@@ -61,7 +61,8 @@ namespace Mono.Cecil.PE {
 			if (metadataOnly)
 				return;
 
-			this.pe64 = module.Architecture == TargetArchitecture.AMD64 || module.Architecture == TargetArchitecture.IA64 || module.Architecture == TargetArchitecture.ARM64;
+			this.pe64 = module.Architecture == TargetArchitecture.AMD64 || module.Architecture == TargetArchitecture.IA64 || module.Architecture == TargetArchitecture.ARM64 ||
+				    module.Architecture == TargetArchitecture.RiscV64;
 			this.has_reloc = module.Architecture == TargetArchitecture.I386;
 			this.GetDebugHeader ();
 			this.GetWin32Resources ();

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -987,7 +987,8 @@ namespace Mono.Cecil {
 			var map = new TextMap ();
 			map.AddMap (TextSegment.ImportAddressTable, module.Architecture == TargetArchitecture.I386 ? 8 : 0);
 			map.AddMap (TextSegment.CLIHeader, 0x48, 8);
-			var pe64 = module.Architecture == TargetArchitecture.AMD64 || module.Architecture == TargetArchitecture.IA64 || module.Architecture == TargetArchitecture.ARM64;
+			var pe64 = module.Architecture == TargetArchitecture.AMD64 || module.Architecture == TargetArchitecture.IA64 || module.Architecture == TargetArchitecture.ARM64 ||
+				   module.Architecture == TargetArchitecture.RiscV64;
 			// Alignment of the code segment must be set before the code is written
 			// These alignment values are probably not necessary, but are being left in
 			// for now in case something requires them.

--- a/Mono.Cecil/ModuleKind.cs
+++ b/Mono.Cecil/ModuleKind.cs
@@ -32,6 +32,7 @@ namespace Mono.Cecil {
 		ARM = 0x01c0,
 		ARMv7 = 0x01c4,
 		ARM64 = 0xaa64,
+		RiscV64 = 0x5064,
 	}
 
 	[Flags]


### PR DESCRIPTION
It is for supporting RISCV64 in cecil
Add RISCV64 to TargetArchitecture and update checks for pe64

Part of https://github.com/dotnet/runtime/issues/84834
cc @dotnet/samsung