### PR TITLE
Resolve `.dll` before `.exe`

### DIFF
--- a/Mono.Cecil/BaseAssemblyResolver.cs
+++ b/Mono.Cecil/BaseAssemblyResolver.cs
@@ -209,7 +209,7 @@ namespace Mono.Cecil {
 
 		protected virtual AssemblyDefinition SearchDirectory (AssemblyNameReference name, IEnumerable<string> directories, ReaderParameters parameters)
 		{
-			var extensions = name.IsWindowsRuntime ? new [] { ".winmd", ".dll" } : new [] { ".exe", ".dll" };
+			var extensions = name.IsWindowsRuntime ? new [] { ".winmd", ".dll" } : new [] { ".dll", ".exe" };
 			foreach (var directory in directories) {
 				foreach (var extension in extensions) {
 					string file = Path.Combine (directory, name.Name + extension);


### PR DESCRIPTION
In the .NET world, executable assemblies have a Foo.exe and Foo.dll file.  Foo.exe is not a managed assembly and attempting to load it will cause
```
System.BadImageFormatException: Format of the executable (.exe) or library (.dll) is invalid.
   at Mono.Cecil.PE.ImageReader.ReadOptionalHeaders(UInt16& subsystem, UInt16& dll_characteristics) in C:\UnitySrc\dev\il2cpp-18\external\cecil\Mono.Cecil.PE\ImageReader.cs:line 198
   at Mono.Cecil.PE.ImageReader.ReadImage() in C:\UnitySrc\dev\il2cpp-18\external\cecil\Mono.Cecil.PE\ImageReader.cs:line 86
   at Mono.Cecil.PE.ImageReader.ReadImage(Disposable`1 stream, String file_name) in C:\UnitySrc\dev\il2cpp-18\external\cecil\Mono.Cecil.PE\ImageReader.cs:line 766
   at Mono.Cecil.ModuleDefinition.ReadModule(Disposable`1 stream, String fileName, ReaderParameters parameters) in C:\UnitySrc\dev\il2cpp-18\external\cecil\Mono.Cecil\ModuleDefinition.cs:line 1141
   at Mono.Cecil.ModuleDefinition.ReadModule(String fileName, ReaderParameters parameters) in C:\UnitySrc\dev\il2cpp-18\external\cecil\Mono.Cecil\ModuleDefinition.cs:line 1110
   at Mono.Cecil.AssemblyDefinition.ReadAssembly(String fileName, ReaderParameters parameters) in C:\UnitySrc\dev\il2cpp-18\external\cecil\Mono.Cecil\AssemblyDefinition.cs:line 132
 ```

By attempting to locate `.dll` files before `.exe` this problem can be avoided.

For context, I hit this in one of our resolvers while attempting to resolve all of the dependencies of an executable that referenced another executable.  I fixed our resolver the same way but noticed `BaseAssemblyResolver` had the same behavior we had so I thought I'd upstream the change.