### PR TITLE
Dispose IDisposables in NativePdbWriter

### DIFF
--- a/symbols/pdb/Mono.Cecil.Pdb/NativePdbWriter.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/NativePdbWriter.cs
@@ -75,7 +75,7 @@ namespace Mono.Cecil.Pdb {
 
 		void DefineCustomMetadata (MethodDebugInformation info, MetadataToken import_parent)
 		{
-			var metadata = new CustomMetadataWriter (this.writer);
+			using var metadata = new CustomMetadataWriter (this.writer);
 
 			if (import_parent.RID != 0) {
 				metadata.WriteForwardInfo (import_parent);
@@ -367,6 +367,7 @@ namespace Mono.Cecil.Pdb {
 		public void Dispose ()
 		{
 			stream.Dispose ();
+			writer.Dispose ();
 		}
 	}
 }


### PR DESCRIPTION
- The code creates a local variable that's an IDisposable (CustomMetadataWriter), but doesn't call Dispose() on it.

- The CustomMetadataWriter class holds two IDisposables (MemoryStream and BinaryStreamWriter), but was only Dispose()ing one of them.