### PR TITLE
Fixed: SymWriter COM object is not released on exception

### DIFF
--- a/symbols/pdb/Mono.Cecil.Pdb/NativePdbWriter.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/NativePdbWriter.cs
@@ -267,6 +267,7 @@ namespace Mono.Cecil.Pdb {
 
 		public void Dispose ()
 		{
+			writer.Close ();
 		}
 	}
 

--- a/symbols/pdb/Mono.Cecil.Pdb/SymWriter.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/SymWriter.cs
@@ -30,6 +30,7 @@ namespace Mono.Cecil.Pdb
 
 		readonly ISymUnmanagedWriter2 writer;
 		readonly Collection<ISymUnmanagedDocumentWriter> documents;
+		bool closed = false;
 
 		public SymWriter ()
 		{
@@ -78,11 +79,14 @@ namespace Mono.Cecil.Pdb
 
 		public void Close ()
 		{
-			writer.Close ();
-			Marshal.ReleaseComObject (writer);
+			if( !closed ) {
+				closed = true;
+				writer.Close ();
+				Marshal.ReleaseComObject ( writer );
 
-			foreach (var document in documents)
-				Marshal.ReleaseComObject (document);
+				foreach( var document in documents )
+					Marshal.ReleaseComObject ( document );
+			}
 		}
 
 		public void CloseMethod ()

--- a/symbols/pdb/Mono.Cecil.Pdb/SymWriter.cs
+++ b/symbols/pdb/Mono.Cecil.Pdb/SymWriter.cs
@@ -79,14 +79,15 @@ namespace Mono.Cecil.Pdb
 
 		public void Close ()
 		{
-			if( !closed ) {
-				closed = true;
-				writer.Close ();
-				Marshal.ReleaseComObject ( writer );
+			if (closed)
+				return;
 
-				foreach( var document in documents )
-					Marshal.ReleaseComObject ( document );
-			}
+			closed = true;
+			writer.Close ();
+			Marshal.ReleaseComObject (writer);
+
+			foreach (var document in documents)
+				Marshal.ReleaseComObject (document);
 		}
 
 		public void CloseMethod ()


### PR DESCRIPTION
### The Problem

Accessing a PDB file edited with Cecil randomly produces errors about the file being locked.
Problem observed when being used in coverlet:
https://github.com/coverlet-coverage/coverlet/issues/1471

This is caused by an exclusive file handle held by the SymWriter COM object.
It is not released before the COM object is released.
In normal execution, `NativePdbWriter.Write` calls `SymWriter.Close` at the end,
which in turn calls `Marshal.ReleaseComObject`, releasing the object and file handle.
But if an exception causes `NativePdbWriter.Write` to never be called, there is no call to `SymWriter.Close`,
which in turn means `Marshal.ReleaseComObject` is left uncalled.

The garbage collector will eventually destroy the object and thereby release the COM object, but that happens non-deterministically. The result was random file access issues with the PDB file.

### The Solution

Luckily `NativePdbWriter` is `IDisposable`. I added a call to `writer.Close` to the `Dispose`. But now `Close` could be called twice, so I had to add a boolean to SymWriter to avoid releasing the resources twice.