### PR TITLE
C#13: Add the "allow byref-like" anti-constraint

### DIFF
--- a/Mono.Cecil/GenericParameter.cs
+++ b/Mono.Cecil/GenericParameter.cs
@@ -150,6 +150,11 @@ namespace Mono.Cecil {
 			set { attributes = attributes.SetMaskedAttributes ((ushort) GenericParameterAttributes.VarianceMask, (ushort) GenericParameterAttributes.Contravariant, value); }
 		}
 
+		public bool HasNoSpecialConstraint {
+			get { return attributes.GetMaskedAttributes ((ushort) GenericParameterAttributes.SpecialConstraintMask, (ushort) GenericParameterAttributes.NoSpecialConstraint); }
+			set { attributes = attributes.SetMaskedAttributes ((ushort) GenericParameterAttributes.SpecialConstraintMask, (ushort) GenericParameterAttributes.NoSpecialConstraint, value); }
+		}
+
 		public bool HasReferenceTypeConstraint {
 			get { return attributes.GetAttributes ((ushort) GenericParameterAttributes.ReferenceTypeConstraint); }
 			set { attributes = attributes.SetAttributes ((ushort) GenericParameterAttributes.ReferenceTypeConstraint, value); }
@@ -163,6 +168,11 @@ namespace Mono.Cecil {
 		public bool HasDefaultConstructorConstraint {
 			get { return attributes.GetAttributes ((ushort) GenericParameterAttributes.DefaultConstructorConstraint); }
 			set { attributes = attributes.SetAttributes ((ushort) GenericParameterAttributes.DefaultConstructorConstraint, value); }
+		}
+
+		public bool AllowsByRefLike {
+			get { return attributes.GetAttributes ((ushort) GenericParameterAttributes.AllowByRefLike); }
+			set { attributes = attributes.SetAttributes ((ushort) GenericParameterAttributes.AllowByRefLike, value); }
 		}
 
 		#endregion

--- a/Mono.Cecil/GenericParameterAttributes.cs
+++ b/Mono.Cecil/GenericParameterAttributes.cs
@@ -19,9 +19,11 @@ namespace Mono.Cecil {
 		Covariant		= 0x0001,
 		Contravariant	= 0x0002,
 
-		SpecialConstraintMask			= 0x001c,
+		SpecialConstraintMask			= 0x003c,
+		NoSpecialConstraint             = 0x0000,
 		ReferenceTypeConstraint			= 0x0004,
 		NotNullableValueTypeConstraint	= 0x0008,
-		DefaultConstructorConstraint	= 0x0010
+		DefaultConstructorConstraint	= 0x0010,
+		AllowByRefLike					= 0x0020,
 	}
 }


### PR DESCRIPTION
This adds a new `AllowsByRefLike` flag to `GenericParameterAttributes` which, unlike the others, is an anti-constraint (i.e. it removes restrictions rather than adding them) added in C# 13. Because of this, `AllowsByRefLike` was chosen as the corresponding bool property on `GenericParameter` (instead of
`HasAllowByRefLineConstraint`; the constant also does not include `Constraint` in its name).

At the same time, it adds the `NoSpecialConstraint` flag and a corresponding `HasNoSpecialConstraint` property.

Reference: corresponding constants in the CLR code: https://github.com/dotnet/runtime/blob/9daa4b41eb9f157e79eaf05e2f7451c9c8f6dbdc/src/coreclr/inc/corhdr.h#L850