### PR TITLE
Update Ubuntu runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Test
       run: dotnet test --no-build -c Debug Mono.Cecil.sln
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     - name: Build


### PR DESCRIPTION
Ubuntu 20.04 is no longer supported and Github Actions are not running

actions/runner-images#11101