### PR TITLE
Add additional ByteBufferTest tests

### DIFF
--- a/Test/Mono.Cecil.Tests/ByteBufferTests.cs
+++ b/Test/Mono.Cecil.Tests/ByteBufferTests.cs
@@ -12,5 +12,30 @@ namespace Mono.Cecil.Tests {
 			var result = testee.ReadCompressedInt32 ();
 			Assert.AreEqual (-9076, result);
 		}
+
+		// Round-trips WriteCompressedInt32/ReadCompressedInt32 across every encoding-width
+		// boundary of the ECMA-335 compressed signed integer format (1/2/4-byte forms)
+		[TestCase (0)]
+		[TestCase (1)]
+		[TestCase (-1)]
+		[TestCase (63)]
+		[TestCase (-64)]
+		[TestCase (64)]
+		[TestCase (-65)]
+		[TestCase (8191)]
+		[TestCase (-8192)]
+		[TestCase (8192)]
+		[TestCase (-8193)]
+		[TestCase (-8269)]
+		[TestCase (268435455)]
+		[TestCase (-268435456)]
+		public void CompressedInt32RoundTripsAcrossEncodingWidths (int value)
+		{
+			var testee = new ByteBuffer ();
+			testee.WriteCompressedInt32 (value);
+			testee.position = 0;
+			var result = testee.ReadCompressedInt32 ();
+			Assert.AreEqual (value, result);
+		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/132164
Context: https://github.com/unoplatform/uno/issues/24036
Context: 608fac6f22814e3eeb4609c80c0b5f08205e24ed / dotnet/roslyn#958

I've been trying to get a project building for iOS+Native AOT, which invariably would error out in `ilc`:

	Error: Sequence point value is out of range.
	System.BadImageFormatException: Sequence point value is out of range.
	   at System.Reflection.Throw.SequencePointValueOutOfRange() in /_/src/runtime/src/libraries/System.Reflection.Metadata/src/System/Reflection/Throw.cs:line 239
	   at System.Reflection.Metadata.SequencePointCollection.Enumerator.MoveNext() in /_/src/runtime/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/SequencePointCollection.cs:line 86
	   at Internal.TypeSystem.Ecma.PortablePdbSymbolReader.<GetSequencePointsForMethod>d__10.MoveNext() in /_/src/runtime/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PortablePdbSymbolReader.cs:line 147
	   at ILCompiler.Logging.MessageOrigin..ctor(MethodIL, Int32) in /_/src/runtime/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/MessageOrigin.cs:line 65

After quite a bit of investigation, determined that Cecil was apparent cause of the crash, because multiple "involved parties" did *not* have the fix present in commit 608fac6f, resulting in a "failure cascade":

 1. `<Csc/>` task produces `.pdb` file

 2. Uno `<EmbeddedResourceInjectorTask_v0/>` task uses Cecil to update (1), introduces "Invalid compressed integer".

 3. `illink` -- which has its own copy of Cecil, from the dotnet/cecil fork -- consumes (2), turning "Invalid compressed integer" values into *different* values.

 4. `ilc` processes `pdb` produced from (3), fails with `BadImageFormatException: Sequence point value is out of range`.

A "full stack" fix involves updating Uno to use Mono.Cecil 0.11.6, which contains 608fac6f, *and also* updating `illink` to also contain the fix from 608fac6f.  (PR does not yet exist.)

However, as part of this investigation, Claude cooked up a patch to dotnet/cecil along with unit test updates to ByteBufferTests. Of interest is that the suggested Claude fix for dotnet/cecil also causes the original ByteBufferTests test from 608fac6f to pass (yay), but not all of the new tests.  Meanwhile, jbevain/cecil *does* pass all of the suggested new tests.

Record the new tests for posterity, and to reduce future drift between jbevain/cecil and dotnet/cecil.